### PR TITLE
gitignore: fix incorrect formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,8 +106,9 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
 
+# added for RIA/Silverlight projects
+Generated_Code
 
 
 ############


### PR DESCRIPTION
The acceptable pattern formats for .gitignore are enumerated in the
manual[1]. Surprisingly the only valid form for comments are lines
starting with a `#` character. A `#` character anywhere else will
not be parsed as one might expect.

Move the comment on `Generated_Code` above the pattern.

Leaving the comment where it is will a) not result in `Generated_Code`
being ignored and b) cause @rjw57's vim config to explode when opening
any file :).

[1] http://git-scm.com/docs/gitignore, "PATTERN FORMAT" section
