### PR TITLE
SPECULATIVE: fix Zend framework library path

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -40,7 +40,7 @@ ini_set('upload_max_filesize','16M');
 // Ensure library is on include_path directory setup and class loading
 set_include_path(
         '.' . PATH_SEPARATOR . '../library/'
-        . PATH_SEPARATOR . '../library/Zend/'
+        . PATH_SEPARATOR . '../library/Zend/library/'
         . PATH_SEPARATOR . '../library/ZendX/'
         . PATH_SEPARATOR . '../library/Pas/'
         . PATH_SEPARATOR . '../library/Arc2/'


### PR DESCRIPTION
**NOTE:** I have close to zero experience with Zend or PHP so please review
this change carefully. No ego bruising if this is closed with extreme
prejudice.

On my machine, launching the development webserver via `php -S localhost:8080
-t public_html` causes the Autoloader-including to fail. The Zend framework
Autoloader is located in `library/Zend/Loader/` within the Zend
sub-module[1].

I've no idea if this matches the f.o.uk server setup but I suppose this could
be one of those bugs only found by some idiot like myself trying to clone the
repo afresh :).

[1] https://github.com/zendframework/zf1/tree/master/library/Zend/Loader
