### PR TITLE
gitignore: move trailing comment to line above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,8 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
+# v- added for RIA/Silverlight projects
+Generated_Code
 
 
 


### PR DESCRIPTION
A re-introduction of #181. The gitignore file has a dangling comment on a line
which makes over-pedantic tools moan. (In this case, vim screams blue murder
whenever I open a file in the tree.)