### PR TITLE
Acronym helper: fix possible undefined variable "$newText"

### DIFF
--- a/library/Pas/View/Helper/Acronyms.php
+++ b/library/Pas/View/Helper/Acronyms.php
@@ -66,6 +66,10 @@ class Pas_View_Helper_Acronyms extends Zend_View_Helper_Abstract
     {
         $text = $this->getString();
         $abbrev = $this->getAcronyms();
+
+        // Ensure that text is always returned even if there are no acronyms.
+        $newText = trim($text);
+
         foreach ($abbrev as $acronym => $expanded) {
             $text = preg_replace("|(?!<[^<>]*?)(?<![?.&])\b$acronym\b(?!:)(?![^<>]*?>)|msU",
                 "<abbr title=\"$expanded\">$acronym</abbr>", $text);


### PR DESCRIPTION
In the rare case that there are no acronyms in the database, the Acronym helper
will attempt to return an undefined variable. Ensure that $newText always
exists (with the trimmed value of $text) so that is may be returned.