### PR TITLE
Remove HTML comments in PDF report output.

### DIFF
--- a/app/modules/database/views/scripts/ajax/pdf.phtml
+++ b/app/modules/database/views/scripts/ajax/pdf.phtml
@@ -14,7 +14,6 @@ $mpdf->SetDisplayMode('fullpage');
 $mpdf->WriteHTML('<h1 style="font-size: 14px;">Export of search results from finds.org.uk</h1>');
 //?>
 <?php foreach ($this->data as $data): ?>
-<!--    --><?php //echo $this->purify()->setValue($this->partial('partials/database/pdf/results.phtml', $data));?>
 <?php $mpdf->WriteHTML(utf8_encode($this->partial('partials/database/pdf/results.phtml', $data))); ?>
 <?php endforeach; ?>
 <?php $mpdf->WriteHTML($tableEnd); ?>


### PR DESCRIPTION
Generated PDF reports have a large number of blank HTML comments at the start of the file before the PDF output proper starts. Removing them from the top of the file results in a PDF file which can be opened on Google Drive Viewer (am in pub so testing on phone). Since the troublesome line noted by @portableant is commented out, remove it. Closes #1004.