### PR TITLE
Make btn-navbar spans display (fixes #1034)

### DIFF
--- a/public_html/css/custom-bootstrap.css
+++ b/public_html/css/custom-bootstrap.css
@@ -153,6 +153,10 @@ ul.facetExpand li {
     padding-bottom: 7px;
 }
 
+.btn.btn-navbar .icon-bar{
+    display: block;
+}
+
 #period-object-cloud li {
     display: inline-block;
 }


### PR DESCRIPTION
font-awesome.css has this rule which was conflicting:
```
.btn [class^="icon-"]{
    display: inline;
}
```