### PR TITLE
Fix #1038 - homepage carousel images

### DIFF
--- a/public_html/css/home-custom.css
+++ b/public_html/css/home-custom.css
@@ -45,17 +45,21 @@
       position: absolute;
       top: 0;
       left: 0;
-      min-width: 100%;
+      width: 100%;
       height: 500px;
+      object-fit: cover;
+      object-position: 80% 50%;
     }
 
 
-    .carousel-caption {
-      background-color: transparent;
+    .carousel-caption {      
       position: static;
       max-width: 550px;
-      padding: 0 20px;
+      padding: 25px 50px;
       margin-top: 200px;
+      background-color: rgba(0,0,0,.4);
+      position: relative;
+      left: -50px;
     }
     .carousel-caption h1,
     .carousel-caption .lead {
@@ -175,7 +179,7 @@
       }
       .carousel-caption {
         width: 65%;
-        padding: 0 70px;
+        padding: 22px 70px;
         margin-top: 100px;
       }
       .carousel-caption h1 {


### PR DESCRIPTION
The property `object-fit` is not in IE or Edge yet so consider using background-images instead to get full browser coverage of this design.

As most of the images have the subject focus on the right, I used the `object-position` property to show mostly that side of the image.

Also updated `.carousel-caption` so the text is easier to read when there is an image behind.