### PR TITLE
Should hide session message from print

### DIFF
--- a/public_html/css/print.css
+++ b/public_html/css/print.css
@@ -28,7 +28,9 @@
 .btn,
 #slider,
 .sidebar-nav,
-#footer
+#footer,
+#session-timeout-dialog-logout,
+#session-timeout-dialog
 {
 	display:none;
 }


### PR DESCRIPTION
@s-moon I had this commit on my local version. That should fix the issue reported on the forum.