### PR TITLE
Fix hamburger menu on mobile

### DIFF
--- a/public_html/css/home-custom.css
+++ b/public_html/css/home-custom.css
@@ -12,8 +12,15 @@
     /* CUSTOMIZE THE NAVBAR
     -------------------------------------------------- */
 
-  
+    /* CUSTOMIZE SESSION EXPIRE DIALOG
+    -------------------------------------------------- */
+    .modal.fade.in {
+        display: block;
+    }
 
+    .modal.fade {
+        display: none;
+    }
 
     /* CUSTOMIZE THE CAROUSEL
     -------------------------------------------------- */


### PR DESCRIPTION
When logged in to the database, the users where unable to use the menu
by clicking on the hamburger icon.

This was caused by the session expire dialog being on top of the menu
icon, but with opacity 0.  On desktop the dialog was moved out of the way.

To rectify, the dialog now has 'Display:none' when not being shown,
stopping this issue while still keeping the fade in effect.

**Fixes #1318** 