### PR TITLE
64478 3D Model Fix

### DIFF
--- a/app/views/scripts/partials/database/3D/model.phtml
+++ b/app/views/scripts/partials/database/3D/model.phtml
@@ -5,7 +5,9 @@
  * Date: 12/12/14
  * Time: 10:40
  */
+
 ?>
-<iframe width="<?php echo $this->width; ?>" height="<?php echo $this->height; ?>"
-        src="https://sketchfab.com/3d-models/<?php echo $this->modelID; ?>/embed" frameborder="0" allowfullscreen
-        mozallowfullscreen="true" webkitallowfullscreen="true" onmousewheel="" class="pull-right"></iframe>
+<iframe width="<?= $this->width; ?>" height="<?= $this->height; ?>"
+        src="https://sketchfab.com/3d-models/<?= $this->modelID; ?>/embed" frameborder="0" allowfullscreen
+        mozallowfullscreen="true" webkitallowfullscreen="true" onmousewheel="" class="pull-right">
+</iframe>

--- a/app/views/scripts/partials/database/3D/model.phtml
+++ b/app/views/scripts/partials/database/3D/model.phtml
@@ -8,6 +8,6 @@
 
 ?>
 <iframe width="<?= $this->width; ?>" height="<?= $this->height; ?>"
-        src="https://sketchfab.com/3d-models/<?= $this->modelID; ?>/embed" frameborder="0" allowfullscreen
+        src="<?= $this->baseurl; ?><?= $this->modelID; ?>/embed" frameborder="0" allowfullscreen
         mozallowfullscreen="true" webkitallowfullscreen="true" onmousewheel="" class="pull-right">
 </iframe>

--- a/app/views/scripts/partials/database/3D/model.phtml
+++ b/app/views/scripts/partials/database/3D/model.phtml
@@ -7,5 +7,5 @@
  */
 ?>
 <iframe width="<?php echo $this->width; ?>" height="<?php echo $this->height; ?>"
-        src="https://sketchfab.com/models/<?php echo $this->modelID; ?>/embed" frameborder="0" allowfullscreen
+        src="https://sketchfab.com/3d-models/<?php echo $this->modelID; ?>/embed" frameborder="0" allowfullscreen
         mozallowfullscreen="true" webkitallowfullscreen="true" onmousewheel="" class="pull-right"></iframe>

--- a/app/views/scripts/partials/database/3D/small.phtml
+++ b/app/views/scripts/partials/database/3D/small.phtml
@@ -6,4 +6,4 @@
  * Time: 22:54
  */
 ?>
-<a href="https://sketchfab.com/models/<?php echo $this->modelID;?>"><img src="<?php echo $this->thumbnail_url;?>" width="100px" class="img-polaroid" /></a>
+<a href="https://sketchfab.com/3d-models/<?php echo $this->modelID;?>"><img src="<?php echo $this->thumbnail_url;?>" width="100px" class="img-polaroid" /></a>

--- a/app/views/scripts/partials/database/3D/small.phtml
+++ b/app/views/scripts/partials/database/3D/small.phtml
@@ -7,6 +7,6 @@
  */
 
 ?>
-<a href="https://sketchfab.com/3d-models/<?= $this->modelID; ?>">
+<a href="<?= $this->baseurl; ?><?= $this->modelID; ?>">
     <img src="<?= $this->thumbnail_url; ?>" width="100px" class="img-polaroid"/>
 </a>

--- a/app/views/scripts/partials/database/3D/small.phtml
+++ b/app/views/scripts/partials/database/3D/small.phtml
@@ -5,5 +5,8 @@
  * Date: 20/01/15
  * Time: 22:54
  */
+
 ?>
-<a href="https://sketchfab.com/3d-models/<?php echo $this->modelID;?>"><img src="<?php echo $this->thumbnail_url;?>" width="100px" class="img-polaroid" /></a>
+<a href="https://sketchfab.com/3d-models/<?= $this->modelID; ?>">
+    <img src="<?= $this->thumbnail_url; ?>" width="100px" class="img-polaroid"/>
+</a>

--- a/library/Pas/Service/SketchFabOembed.php
+++ b/library/Pas/Service/SketchFabOembed.php
@@ -1,9 +1,7 @@
 <?php
 
 /** A service class for shortening and expanding links with goo.gl
- *
  * An example of use:
- *
  * <code>
  * <?php
  * $shortener = new Pas_Service_GoogleShortUrl($key);
@@ -11,18 +9,18 @@
  * $analytics = $shortener->analytics($url);
  * ?>
  * </code>
- * @author Daniel Pett <dpett@britishmuseum.org>
+ *
+ * @author        Daniel Pett <dpett@britishmuseum.org>
  * @copyright (c) 2014 Daniel Pett
- * @category   Pas
- * @package    Pas_Service
- * @version 1
- * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
+ * @category      Pas
+ * @package       Pas_Service
+ * @version       1
+ * @license       http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
  */
 class Pas_Service_SketchFabOembed
 {
 
     /** The Google short url
-     *
      */
     const SFAB = 'https://sketchfab.com/oembed';
 
@@ -40,6 +38,7 @@ class Pas_Service_SketchFabOembed
     }
 
     /** Get analytics for a URL
+     *
      * @access public
      * @param string $shortUrl
      * @return object $response
@@ -59,6 +58,7 @@ class Pas_Service_SketchFabOembed
     }
 
     /** Decode the response from JSON
+     *
      * @access public
      * @param string $response
      * @return object $json

--- a/library/Pas/Service/SketchFabOembed.php
+++ b/library/Pas/Service/SketchFabOembed.php
@@ -20,11 +20,23 @@
 class Pas_Service_SketchFabOembed
 {
 
-    /** The Google short url
-     */
-    const SFAB = 'https://sketchfab.com/oembed';
-
     protected $_url;
+
+    /** Sketchfab base url
+     *
+     * @access protected
+     * @var null
+     */
+    protected $_sketchfabBaseUrl = null;
+
+    /** Constructor
+     *
+     * @access public
+     */
+    function __construct()
+    {
+        $this->_sketchfabBaseUrl = Zend_Registry::get('config')->webservice->sketchfab->toArray();
+    }
 
     public function setUrl($url)
     {
@@ -34,7 +46,7 @@ class Pas_Service_SketchFabOembed
 
     public function getUrl()
     {
-        return 'https://sketchfab.com/3d-models/' . $this->_url;
+        return $this->_sketchfabBaseUrl['baseurl'] . $this->_url;
     }
 
     /** Get analytics for a URL
@@ -46,7 +58,7 @@ class Pas_Service_SketchFabOembed
     public function getOembed()
     {
         $client = new Zend_Http_Client();
-        $client->setUri(self::SFAB);
+        $client->setUri($this->_sketchfabBaseUrl['oembed']);
         $client->setMethod(Zend_Http_Client::GET);
         $client->setParameterGet('url', $this->getUrl());
         $response = $client->request();

--- a/library/Pas/Service/SketchFabOembed.php
+++ b/library/Pas/Service/SketchFabOembed.php
@@ -36,7 +36,7 @@ class Pas_Service_SketchFabOembed
 
     public function getUrl()
     {
-        return 'https://sketchfab.com/models/' . $this->_url;
+        return 'https://sketchfab.com/3d-models/' . $this->_url;
     }
 
     /** Get analytics for a URL

--- a/library/Pas/View/Helper/SketchFab.php
+++ b/library/Pas/View/Helper/SketchFab.php
@@ -24,6 +24,12 @@
 
 class Pas_View_Helper_SketchFab extends Zend_View_Helper_Abstract {
 
+    /** Sketchfab base url
+     * @access protected
+     * @var null
+     */
+    protected $_sketchfabBaseUrl = NULL;
+
     /** Set the width
      * @access protected
      * @var null
@@ -41,6 +47,14 @@ class Pas_View_Helper_SketchFab extends Zend_View_Helper_Abstract {
      * @var null
      */
     protected $_modelID = NULL;
+
+
+    /** Constructor
+     * @access public
+     */
+    function __construct() {
+        $this->_sketchfabBaseUrl = Zend_Registry::get('config')->webservice->sketchfab->toArray();
+    }
 
     /** Get the height
      * @return mixed
@@ -126,7 +140,8 @@ class Pas_View_Helper_SketchFab extends Zend_View_Helper_Abstract {
         $options = array(
             'modelID' => $this->getModelID(),
             'width' => $this->getWidth(),
-            'height' => $this->getHeight()
+            'height' => $this->getHeight(),
+            'baseurl' => $this->_sketchfabBaseUrl['baseurl']
         );
         $html = '';
         if(isset($options['modelID'])) {

--- a/library/Pas/View/Helper/SketchFabThumbnail.php
+++ b/library/Pas/View/Helper/SketchFabThumbnail.php
@@ -28,8 +28,20 @@
  */
 class Pas_View_Helper_SketchFabThumbnail extends Zend_View_Helper_Abstract
 {
+    /** Sketchfab base url
+     * @access protected
+     * @var null
+     */
+    protected $_sketchfabBaseUrl = NULL;
 
     protected $_modelID;
+
+    /** Constructor
+     * @access public
+     */
+    function __construct() {
+        $this->_sketchfabBaseUrl = Zend_Registry::get('config')->webservice->sketchfab->toArray();
+    }
 
     /**
      * @return mixed
@@ -66,7 +78,7 @@ class Pas_View_Helper_SketchFabThumbnail extends Zend_View_Helper_Abstract
     public function render()
     {
         $oembed = get_object_vars($this->getData());
-        $modelID = array('modelID' => $this->getModelID());
+        $modelID = array('modelID' => $this->getModelID(), 'baseurl' => $this->_sketchfabBaseUrl['baseurl']);
         $data = array_merge($oembed, $modelID);
         $html = $this->view->partial('partials/database/3D/small.phtml', $data);
         return $html;


### PR DESCRIPTION
The link to Sketchfab 3D models has changed from https://sketchfab.com/models/ to https://sketchfab.com/3d-models/. 

This lead to links to the model redirecting to the homepage and the 3d viewer displaying a 404 error. 

This fix replaces the out of date links, and cleans up the code for the three files.