### PR TITLE
65593 Welcome page URL and styling

### DIFF
--- a/app/modules/database/controllers/MyschemeController.php
+++ b/app/modules/database/controllers/MyschemeController.php
@@ -3,21 +3,21 @@
 /** Controller for displaying individual's finds on the database.
  *
  * @category   Pas
- * @package Pas_Controller_Action
+ * @package    Pas_Controller_Action
  * @subpackage Admin
  * @copyright  Copyright (c) 2011 DEJ Pett dpett @ britishmuseum . org
- * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
- * @author Daniel Pett <dpett at britishmuseum.org>
- * @version 1
- * @uses SolrForm
- * @uses Pas_Solr_Handler
- * @uses Pas_ArrayFunctions
- *
+ * @license    http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
+ * @author     Daniel Pett <dpett at britishmuseum.org>
+ * @version    1
+ * @uses       SolrForm
+ * @uses       Pas_Solr_Handler
+ * @uses       Pas_ArrayFunctions
  */
 class Database_MyschemeController extends Pas_Controller_Action_Admin
 {
 
     /** The init function
+     *
      * @access public
      * @return void
      */
@@ -29,18 +29,21 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** The array cleaning functions
+     *
      * @access protected
      * @var \Pas_ArrayFunctions
      */
     protected $_cleaner;
 
     /** The solr object
+     *
      * @access protected
      * @var \Pas_Solr_Handler
      */
     protected $_solr;
 
     /** Get the solr object
+     *
      * @access public
      * @return \Pas_Solr_Handler
      */
@@ -51,6 +54,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** The array cleaner
+     *
      * @access public
      * @return \Pas_ArrayFunctions
      */
@@ -61,11 +65,11 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** the redirect string
-     *
      */
     const REDIRECT = '/database/myscheme/';
 
     /** Redirect of the user due to no action existing.
+     *
      * @access public
      * @return void
      */
@@ -78,6 +82,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** List of user's finds that they have entered.
+     *
      * @access public
      * @return void
      */
@@ -91,14 +96,27 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
         $params = $this->getAllParams();
         $search = $this->getSolr();
         $search->setCore('objects');
-        $search->setFields(array(
-            'id', 'identifier', 'objecttype',
-            'title', 'broadperiod', 'imagedir',
-            'filename', 'thumbnail', 'old_findID',
-            'description', 'county', 'workflow',
-            'knownas', 'fourFigure', 'updated',
-            'created', 'findIdentifier'
-        ));
+        $search->setFields(
+            array(
+                'id',
+                'identifier',
+                'objecttype',
+                'title',
+                'broadperiod',
+                'imagedir',
+                'filename',
+                'thumbnail',
+                'old_findID',
+                'description',
+                'county',
+                'workflow',
+                'knownas',
+                'fourFigure',
+                'updated',
+                'created',
+                'findIdentifier'
+            )
+        );
         $search->setFacets(array('objectType', 'county', 'broadperiod', 'institution'));
         $search->setMyfinds(true);
         if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())
@@ -107,8 +125,11 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
             $params = $this->getCleaner()->array_cleanup($form->getValues());
             $params['createdBy'] = $this->getIdentityForForms();
             $this->_helper->Redirector->gotoSimple(
-                'myfinds', 'myscheme', 'database',
-                $params);
+                'myfinds',
+                'myscheme',
+                'database',
+                $params
+            );
         } else {
             $form->populate($this->getAllParams());
         }
@@ -126,6 +147,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** Recorded by flo finds list action
+     *
      * @access public
      * @return void
      */
@@ -140,16 +162,29 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
             $params['-createdBy'] = $this->getAccount()->id;
             $search = $this->getSolr();
             $search->setCore('objects');
-            $search->setFields(array(
-                    'id', 'identifier', 'objecttype',
-                    'title', 'broadperiod', 'imagedir',
-                    'filename', 'thumbnail', 'old_findID',
-                    'description', 'county', 'workflow',
-                    'knownas', 'fourFigure', 'updated',
-                    'created', 'findIdentifier'
+            $search->setFields(
+                array(
+                    'id',
+                    'identifier',
+                    'objecttype',
+                    'title',
+                    'broadperiod',
+                    'imagedir',
+                    'filename',
+                    'thumbnail',
+                    'old_findID',
+                    'description',
+                    'county',
+                    'workflow',
+                    'knownas',
+                    'fourFigure',
+                    'updated',
+                    'created',
+                    'findIdentifier'
                 )
             );
-            $this->view->solrParams = 'finderID:' . $this->getAccount()->peopleID . ' -createdBy:' . $this->getAccount()->id;
+            $this->view->solrParams = 'finderID:' . $this->getAccount()->peopleID . ' -createdBy:' . $this->getAccount(
+                )->id;
             $search->setFacets(array('objectType', 'county', 'broadperiod', 'institution'));
             if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())
                 && !is_null($this->getParam('submit'))
@@ -157,8 +192,11 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
                 $params = $this->getCleaner()->array_cleanup($form->getValues());
 
                 $this->_helper->Redirector->gotoSimple(
-                    'recordedbyflos', 'myscheme', 'database',
-                    $params);
+                    'recordedbyflos',
+                    'myscheme',
+                    'database',
+                    $params
+                );
             } else {
                 $form->populate($this->getAllParams());
             }
@@ -177,6 +215,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** Map action
+     *
      * @access public
      * @return void
      */
@@ -186,6 +225,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** the institutional map action
+     *
      * @access public
      * @return void
      */
@@ -195,6 +235,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** Finds recorded by an institution assigned to the user
+     *
      * @access public
      * @return void
      */
@@ -206,27 +247,46 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
         $params = $this->getAllParams();
         $search = $this->getSolr();
         $search->setCore('objects');
-        $search->setFields(array(
-            'id', 'identifier', 'objecttype',
-            'title', 'broadperiod', 'imagedir',
-            'filename', 'thumbnail', 'old_findID',
-            'description', 'county', 'workflow',
-            'fourFigure', 'knownas', 'updated',
-            'created', 'findIdentifier'
-        ));
-        $search->setFacets(array(
-            'objectType', 'county', 'broadperiod',
-            'institution', 'workflow'
-        ));
+        $search->setFields(
+            array(
+                'id',
+                'identifier',
+                'objecttype',
+                'title',
+                'broadperiod',
+                'imagedir',
+                'filename',
+                'thumbnail',
+                'old_findID',
+                'description',
+                'county',
+                'workflow',
+                'fourFigure',
+                'knownas',
+                'updated',
+                'created',
+                'findIdentifier'
+            )
+        );
+        $search->setFacets(
+            array(
+                'objectType',
+                'county',
+                'broadperiod',
+                'institution',
+                'workflow'
+            )
+        );
         if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())
             && !is_null($this->getParam('submit'))
         ) {
-
             if ($form->isValid($form->getValues())) {
                 $params = $this->getCleaner()->array_cleanup($form->getValues());
 
                 $this->_helper->Redirector->gotoSimple(
-                    'myinstitution', 'myscheme', 'database',
+                    'myinstitution',
+                    'myscheme',
+                    'database',
                     $params
                 );
             } else {
@@ -252,6 +312,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** Display all images that a user has added.
+     *
      * @access public
      * @return void
      */
@@ -263,14 +324,27 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
         $params = $this->getAllParams();
         $search = $this->getSolr();
         $search->setCore('images');
-        $search->setFields(array(
-            'id', 'identifier', 'objecttype',
-            'title', 'broadperiod', 'imagedir',
-            'filename', 'thumbnail', 'old_findID',
-            'county', 'licenseAcronym', 'findID',
-            'institution', 'updated',
-            'created', 'findIdentifier', 'recordtype'
-        ));
+        $search->setFields(
+            array(
+                'id',
+                'identifier',
+                'objecttype',
+                'title',
+                'broadperiod',
+                'imagedir',
+                'filename',
+                'thumbnail',
+                'old_findID',
+                'county',
+                'licenseAcronym',
+                'findID',
+                'institution',
+                'updated',
+                'created',
+                'findIdentifier',
+                'recordtype'
+            )
+        );
         $search->setFacets(array('broadperiod', 'county', 'objecttype', 'institution'));
         if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())
             && !is_null($this->getParam('submit'))
@@ -278,7 +352,9 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
             if ($form->isValid($form->getValues())) {
                 $params = $this->getCleaner()->array_cleanup($form->getValues());
                 $this->_helper->Redirector->gotoSimple(
-                    'myimages', 'myscheme', 'database',
+                    'myimages',
+                    'myscheme',
+                    'database',
                     $params
                 );
             } else {
@@ -303,6 +379,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
     }
 
     /** Get all treasure cases for a user
+     *
      * @access public
      * @return void
      */
@@ -313,26 +390,44 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
         $params = $this->getAllParams();
         $search = $this->getSolr();
         $search->setCore('objects');
-        $search->setFields(array(
-                'id', 'identifier', 'objecttype',
-                'title', 'broadperiod', 'imagedir',
-                'filename', 'thumbnail', 'old_findID',
-                'description', 'county', 'workflow',
-                'updated', 'created', 'findIdentifier'
+        $search->setFields(
+            array(
+                'id',
+                'identifier',
+                'objecttype',
+                'title',
+                'broadperiod',
+                'imagedir',
+                'filename',
+                'thumbnail',
+                'old_findID',
+                'description',
+                'county',
+                'workflow',
+                'updated',
+                'created',
+                'findIdentifier'
             )
         );
-        $search->setFacets(array(
-            'objectType', 'county', 'broadperiod',
-            'discovered', 'institution', 'workflow'
-        ));
+        $search->setFacets(
+            array(
+                'objectType',
+                'county',
+                'broadperiod',
+                'discovered',
+                'institution',
+                'workflow'
+            )
+        );
         if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())
             && !is_null($this->getParam('submit'))
         ) {
-
             if ($form->isValid($form->getValues())) {
                 $params = $this->getCleaner()->array_cleanup($form->getValues());
                 $this->_helper->Redirector->gotoSimple(
-                    'mytreasurecases', 'myscheme', 'database',
+                    'mytreasurecases',
+                    'myscheme',
+                    'database',
                     $params
                 );
             } else {

--- a/app/modules/database/controllers/MyschemeController.php
+++ b/app/modules/database/controllers/MyschemeController.php
@@ -172,7 +172,7 @@ class Database_MyschemeController extends Pas_Controller_Action_Admin
             $this->view->facets = $search->processFacets();
             $this->view->stats = $search->processStats();
         } else {
-            $this->redirect('/error/accountproblem');
+            $this->redirect('/users/account/explore');
         }
     }
 

--- a/app/modules/users/controllers/AccountController.php
+++ b/app/modules/users/controllers/AccountController.php
@@ -420,4 +420,16 @@ class Users_AccountController extends Pas_Controller_Action_Admin
             $this->getFlash()->addMessage('Please review and correct problems');
         }
     }
+
+
+    public function exploreAction()
+    {
+        $user = $this->getAccount();
+
+        if (!null == $user) {
+            $this->view->user = $user;
+        }
+
+        Zend_Layout::getMvcInstance()->setLayout("error");
+    }
 }

--- a/app/modules/users/controllers/AccountController.php
+++ b/app/modules/users/controllers/AccountController.php
@@ -2,58 +2,70 @@
 
 /** Controller for accessing user account stuff
  *
- * @author Daniel Pett <dpett at britishmuseum.org>
+ * @author     Daniel Pett <dpett at britishmuseum.org>
  * @category   Pas
  * @package    Pas_Controller_Action
  * @subpackage Admin
  * @copyright  Copyright (c) 2011 DEJ Pett dpett @ britishmuseum . org
- * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
- * @version 1
- * @uses Zend_Registry
- * @uses Users
- * @uses ProfileForm
- * @uses Pas_Exception
- * @uses ForgotUsernameForm
- * @uses ActivateForm
- * @uses LoginForm
- * @uses RegisterForm
- * @uses ChangePasswordForm
- * @uses ResetPasswordKeyForm
- * @uses AccountUpgradeForm
- *
+ * @license    http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
+ * @version    1
+ * @uses       Zend_Registry
+ * @uses       Users
+ * @uses       ProfileForm
+ * @uses       Pas_Exception
+ * @uses       ForgotUsernameForm
+ * @uses       ActivateForm
+ * @uses       LoginForm
+ * @uses       RegisterForm
+ * @uses       ChangePasswordForm
+ * @uses       ResetPasswordKeyForm
+ * @uses       AccountUpgradeForm
  */
 class Users_AccountController extends Pas_Controller_Action_Admin
 {
 
     /** The auth class
+     *
      * @access protected
      * @var \Zend_Auth
      */
     protected $_auth;
 
     /** The users model
+     *
      * @access protected
      * @var \Users
      */
     protected $_users;
 
     /** Set up the ACL and contexts
+     *
      * @access public
      * @return void
      */
     public function init()
     {
-        $this->_helper->_acl->allow('public', array(
-            'forgotten', 'register', 'activate',
-            'index', 'logout', 'edit',
-            'forgotusername', 'success', 'resetpassword'
-        ));
+        $this->_helper->_acl->allow(
+            'public',
+            array(
+                'forgotten',
+                'register',
+                'activate',
+                'index',
+                'logout',
+                'edit',
+                'forgotusername',
+                'success',
+                'resetpassword'
+            )
+        );
         $this->_helper->_acl->allow('member', null);
         $this->_auth = Zend_Registry::get('auth');
         $this->_users = new Users();
     }
 
     /** Set up index page
+     *
      * @access public
      * @return void
      */
@@ -63,14 +75,17 @@ class Users_AccountController extends Pas_Controller_Action_Admin
         if (is_null($this->_auth->getIdentity())) {
             $this->_helper->redirector->gotoRouteAndExit(
                 array(
-                    'module' => 'users', 'controller' => 'index'
-                ));
+                    'module' => 'users',
+                    'controller' => 'index'
+                )
+            );
         } else {
             $this->view->users = $this->_users->getUserProfile($this->getIdentityForForms());
         }
     }
 
     /** Logout and clear the identity from the storage
+     *
      * @access public
      * @return void
      */
@@ -82,6 +97,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** Edit the user details
+     *
      * @access public
      * @return void
      * @throws Pas_Exception
@@ -117,6 +133,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** Retrieve the user's user name
+     *
      * @access public
      * @return void
      */
@@ -131,9 +148,11 @@ class Users_AccountController extends Pas_Controller_Action_Admin
             if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())) {
                 if ($form->isValid($form->getValues())) {
                     $userData = $this->_users->getUserByUsername($form->getValue('email'));
-                    $to = array(array(
-                        'email' => $form->getValue('email'),
-                        'name' => $userData[0]['fullname'])
+                    $to = array(
+                        array(
+                            'email' => $form->getValue('email'),
+                            'name' => $userData[0]['fullname']
+                        )
                     );
                     $this->_helper->mailer($userData[0], 'forgottenUsername', $to);
                     $this->getFlash()->addMessage('Account reminder sent to your email address');
@@ -147,6 +166,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** Retrieve a password for a user
+     *
      * @access public
      * @return void
      */
@@ -180,14 +200,17 @@ class Users_AccountController extends Pas_Controller_Action_Admin
                     $updatesdata = array(
                         'activationKey' => $newKey,
                     );
-                    $to = array(array(
-                        'email' => $form->getValue('email'),
-                        'name' => $results[0]['fullname']
-                    ));
+                    $to = array(
+                        array(
+                            'email' => $form->getValue('email'),
+                            'name' => $results[0]['fullname']
+                        )
+                    );
                     $assignData = array_merge(
                         $results[0],
                         array('activationKey' => $newKey)
-                        , $form->getValues()
+                        ,
+                        $form->getValues()
                     );
                     $this->_helper->mailer($assignData, 'forgottenPassword', $to);
                     $where = array();
@@ -209,6 +232,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** Register for an account
+     *
      * @access public
      * @return void
      */
@@ -222,15 +246,16 @@ class Users_AccountController extends Pas_Controller_Action_Admin
             $form = new RegisterForm();
             $this->view->form = $form;
             if ($this->getRequest()->isPost() && $form->isValid($this->_request->getPost())) {
-
-		$recap = $form->getvalue('g-recaptcha-response');
+                $recap = $form->getvalue('g-recaptcha-response');
                 $captcha = $form->getvalue('captcha');
                 unset($recap);
                 unset($captcha);
 
-                $to = array(array(
-                    'email' => $form->getValue('email'),
-                    'name' => $form->getValue('first_name') . ' ' . $form->getValue('last_name'))
+                $to = array(
+                    array(
+                        'email' => $form->getValue('email'),
+                        'name' => $form->getValue('first_name') . ' ' . $form->getValue('last_name')
+                    )
                 );
                 $emailData = array(
                     'email' => $form->getValue('email'),
@@ -238,23 +263,26 @@ class Users_AccountController extends Pas_Controller_Action_Admin
                     'activationKey' => md5($form->getValue('username') . $form->getValue('first_name'))
                 );
 
-	        /*$recap = $form->getvalue('g-recaptcha-response');
-                $captcha = $form->getvalue('captcha');
-                unset($recap);
-                unset($captcha);*/
+                /*$recap = $form->getvalue('g-recaptcha-response');
+                    $captcha = $form->getvalue('captcha');
+                    unset($recap);
+                    unset($captcha);*/
 
                 $this->_users->register($form->getValues());
                 $this->_helper->mailer($emailData, 'activateAccount', $to);
                 $this->getFlash()->addMessage('Your account has been created. Please check your email.');
                 $this->redirect('/users/account/activate/');
                 $form->populate($form->getValues());
-                $this->getFlash()->addMessage('There are a few problems with your registration<br/>
-        Please review and correct them.');
+                $this->getFlash()->addMessage(
+                    'There are a few problems with your registration<br/>
+        Please review and correct them.'
+                );
             }
         }
     }
 
     /** Activate an account
+     *
      * @access public
      * @return void
      */
@@ -278,6 +306,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** On success action
+     *
      * @access public
      * @return void
      */
@@ -296,8 +325,10 @@ class Users_AccountController extends Pas_Controller_Action_Admin
                     $this->redirect($this->_helper->loginRedirect());
                 } else {
                     $this->_auth->clearIdentity();
-                    $this->getFlash()->addMessage('Sorry, there was a problem with your submission.
-                Please check and try again');
+                    $this->getFlash()->addMessage(
+                        'Sorry, there was a problem with your submission.
+                Please check and try again'
+                    );
                     $form->populate($formData);
                 }
             }
@@ -307,6 +338,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** List user's logins
+     *
      * @access public
      * @return void
      */
@@ -319,6 +351,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
 
 
     /** Change a password
+     *
      * @access public
      * @return void
      */
@@ -341,6 +374,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** Upgrade an account
+     *
      * @access public
      * @return void
      */
@@ -366,19 +400,28 @@ class Users_AccountController extends Pas_Controller_Action_Admin
 
                     $attachments = array(ROOT_PATH . '/public_html/documents/tac.pdf');
                     $assignData = array_merge($to[0], $form->getValues());
-                    $toReferee = array(array('email' => $form->getValue('referenceEmail'), 'name' => $form->getValue('reference')));
+                    $toReferee = array(
+                        array(
+                            'email' => $form->getValue('referenceEmail'),
+                            'name' => $form->getValue('reference')
+                        )
+                    );
                     //data, template, to, cc, from, bcc, attachments, subject
-                    $this->sendAdvisers($assignData, $toReferee, $emails,  $attachments );
+                    $this->sendAdvisers($assignData, $toReferee, $emails, $attachments);
                     $this->getFlash()->addMessage('Thank you! We have received your request.');
                     $this->redirect('/users/account/');
                 } else {
                     $form->populate($form->getValues());
-                    $this->getFlash()->addMessage('There are a few problems with your registration<br>
-                    Please review and correct them.');
+                    $this->getFlash()->addMessage(
+                        'There are a few problems with your registration<br>
+                    Please review and correct them.'
+                    );
                 }
             }
         } else {
-            $this->getFlash()->addMessage('You can\'t request an upgrade as you already have ' . $this->getRole() . ' status!');
+            $this->getFlash()->addMessage(
+                'You can\'t request an upgrade as you already have ' . $this->getRole() . ' status!'
+            );
             $this->redirect('/users/account/');
         }
     }
@@ -386,14 +429,23 @@ class Users_AccountController extends Pas_Controller_Action_Admin
 
     public function sendAdvisers($assignData, $toReferee, $emails, $attachments)
     {
-        $this->_helper->mailer($assignData, 'upgradeReferee', $toReferee, $emails , null, null, $attachments,
-            'Reference request for Portable Antiquities Scheme Database Access');
+        $this->_helper->mailer(
+            $assignData,
+            'upgradeReferee',
+            $toReferee,
+            $emails,
+            null,
+            null,
+            $attachments,
+            'Reference request for Portable Antiquities Scheme Database Access'
+        );
     }
 
     /** Configure the copy action
-     * @todo Is this needed?
-     * @access public
+     *
      * @return void
+     * @todo   Is this needed?
+     * @access public
      */
     public function configurecopyAction()
     {
@@ -401,6 +453,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
     }
 
     /** Reset a password
+     *
      * @access public
      * @return void
      */

--- a/app/modules/users/controllers/AccountController.php
+++ b/app/modules/users/controllers/AccountController.php
@@ -59,7 +59,7 @@ class Users_AccountController extends Pas_Controller_Action_Admin
                 'resetpassword'
             )
         );
-        $this->_helper->_acl->allow('member', null);
+        $this->_helper->_acl->allow('member', null); //Any role above member can view the pages
         $this->_auth = Zend_Registry::get('auth');
         $this->_users = new Users();
     }
@@ -474,14 +474,14 @@ class Users_AccountController extends Pas_Controller_Action_Admin
         }
     }
 
-
+    /** Return Explore view
+     *
+     * @access member or higher
+     * @return void
+     */
     public function exploreAction()
     {
-        $user = $this->getAccount();
-
-        if (!null == $user) {
-            $this->view->user = $user;
-        }
+        $this->view->user = $this->getAccount();
 
         Zend_Layout::getMvcInstance()->setLayout("error");
     }

--- a/app/modules/users/views/scripts/account/explore.phtml
+++ b/app/modules/users/views/scripts/account/explore.phtml
@@ -1,6 +1,6 @@
 <?php
 
-$this->headTitle("You don't have permission to do that");
+$this->headTitle('Your account is ready!');
 $this->metaBase()->setSubject('Error reports')
     ->setDescription('A page that is displayed when an account is not set up completely')
     ->generate();
@@ -13,8 +13,10 @@ $this->metaBase()->setSubject('Error reports')
         <div class="span8">
             <div class="row">
                 <div class="span8">
-                    <h1 class="lead">Sorry! You don't have permission to do that.</h1>
-                    <p>But please take a look at the links below, and explore the database.</p>
+                    <h1 class="lead">Welcome <?= $this->user->fullname ?>!</h1>
+                    <p>Thank you for registering with the PAS. You are now able to explore the database and see all the
+                        finds
+                        you have recorded.</p>
                     <p>What would you like to do next?</p>
                 </div>
             </div>


### PR DESCRIPTION
Moved the welcome page for new users from `error/accountproblem` to `users/account/explore` to prevent confusion over the URL suggesting there is a problem with the account. 

Both pages have also had their styles updated, fixing the lack of margins on the content resulting in the page touching the edges of the screen. 

- Changed the error/accountproblem text to an error message rather than welcome
- Refactored code
