### PR TITLE
61264 Change wording of the link 'Search database for all examples'

### DIFF
--- a/app/views/scripts/partials/admin/account.phtml
+++ b/app/views/scripts/partials/admin/account.phtml
@@ -1,105 +1,151 @@
 <?php
-   $this->headTitle('Account profile for ' . $this->fullname);
-   $this->metaBase()->setDescription($this->title())->generate();
+
+$this->headTitle('Account profile for ' . $this->fullname);
+$this->metaBase()->setDescription($this->title())->generate();
 ?>
 <div>
-   <h2 class="lead"><?= $this->title() ?></h2>
-   <?php
-      echo $this->Href(array(
-         'module' => 'admin', 
-	 'controller' => 'users',
-         'action' => 'edit',
-         'checkAcl' => true, 
-	 'acl' => 'Zend_Acl',
-         'params' => array('id' => $this->id),
-         'content' => 'Edit account',
-         'attribs' => array('title' => 'Edit account', 'class' => 'btn btn-warning'),
-         'wrapper' => array('tag' => 'div', 'id' => 'action')
-      ));
-   ?>
+    <h2 class="lead"><?= $this->title() ?></h2>
+    <?php
+    echo $this->Href(
+        array(
+            'module' => 'admin',
+            'controller' => 'users',
+            'action' => 'edit',
+            'checkAcl' => true,
+            'acl' => 'Zend_Acl',
+            'params' => array('id' => $this->id),
+            'content' => 'Edit account',
+            'attribs' => array('title' => 'Edit account', 'class' => 'btn btn-warning'),
+            'wrapper' => array('tag' => 'div', 'id' => 'action')
+        )
+    );
+    ?>
 
-   <h3 class="lead">Personal data</h3>
+    <h3 class="lead">Personal data</h3>
 
-   <div id="personal-images">
-      <div id="gravatar">
-         <?php
-            echo $this->gravatar($this->email, array('imgSize' => 80, 'defaultImg' => $this->serverUrl() . $this->baseUrl() . '/assets/gravatar.png', 'secure' => true),
-            array('class' => 'avatar pull-left stelae img-circle', 'title' => $this->fullname . '\'s gravatar representation', 'rating' => 'G', 'width' => 80, 'height' => 80));
-         ?>
-      </div>
-   </div>
-   <p>
-      <?php if (isset($this->username)): ?>
-         Username: <strong><?= $this->username ?></strong><br/>
-      <?php endif; ?>
-      <?php if (isset($this->fullname)): ?>
-         Fullname: <strong><?= $this->fullname ?></strong><br/>
-      <?php endif; ?>
-      <?php if (isset($this->first_name)): ?>
-         Firstname: <strong><?= $this->first_name ?></strong><br/>
-      <?php endif; ?>
-      <?php if (isset($this->last_name)): ?>
-         Lastname: <strong><?= $this->last_name ?></strong><br/>
-      <?php endif; ?>
-      <?php if (!empty($this->email)): ?>
-         Email address: <a href="mailto:<?= $this->email ?>"><strong><?= $this->email ?></strong></a>
-      <?php endif; ?>
-   </p>
+    <div id="personal-images">
+        <div id="gravatar">
+            <?php
+            echo $this->gravatar(
+                $this->email,
+                array(
+                    'imgSize' => 80,
+                    'defaultImg' => $this->serverUrl() . $this->baseUrl() . '/assets/gravatar.png',
+                    'secure' => true
+                ),
+                array(
+                    'class' => 'avatar pull-left stelae img-circle',
+                    'title' => $this->fullname . '\'s gravatar representation',
+                    'rating' => 'G',
+                    'width' => 80,
+                    'height' => 80
+                )
+            );
+            ?>
+        </div>
+    </div>
+    <p>
+        <?php
+        if (isset($this->username)): ?>
+            Username: <strong><?= $this->username ?></strong><br/>
+        <?php
+        endif; ?>
+        <?php
+        if (isset($this->fullname)): ?>
+            Fullname: <strong><?= $this->fullname ?></strong><br/>
+        <?php
+        endif; ?>
+        <?php
+        if (isset($this->first_name)): ?>
+            Firstname: <strong><?= $this->first_name ?></strong><br/>
+        <?php
+        endif; ?>
+        <?php
+        if (isset($this->last_name)): ?>
+            Lastname: <strong><?= $this->last_name ?></strong><br/>
+        <?php
+        endif; ?>
+        <?php
+        if (!empty($this->email)): ?>
+            Email address: <a href="mailto:<?= $this->email ?>"><strong><?= $this->email ?></strong></a>
+        <?php
+        endif; ?>
+    </p>
 </div>
 
 <div>
-   <h3 class="lead">System data</h3>
-   <p>
-      Assigned role: <strong><?= $this->role ?></strong><br/>
-      Recording institution prefix: <strong><?= $this->institution ?></strong><br/>
+    <h3 class="lead">System data</h3>
+    <p>
+        Assigned role: <strong><?= $this->role ?></strong><br/>
+        Recording institution prefix: <strong><?= $this->institution ?></strong><br/>
 
-      <?php if (!is_null($this->peopleID)): ?>
-         Attached to people profile id: <strong><?= $this->personLookup()->setPerson($this->peopleID) ?></strong><br/>
-      <?php endif; ?>
+        <?php
+        if (!is_null($this->peopleID)): ?>
+            Attached to people profile id: <strong><?= $this->personLookup()->setPerson($this->peopleID) ?></strong>
+            <br/>
+        <?php
+        endif; ?>
 
-      Last login to the database: <strong><?= $this->timeAgoInWords($this->escape($this->lastLogin)) ?></strong><br/>
-      Number of visits: <strong><?= $this->visits ?></strong><br/>
+        Last login to the database: <strong><?= $this->timeAgoInWords($this->escape($this->lastLogin)) ?></strong><br/>
+        Number of visits: <strong><?= $this->visits ?></strong><br/>
 
-      <?php if (!empty($this->copyright)): ?>
-         Copyright: <strong><?= $this->copyright ?></strong><br/>
-      <?php endif; ?>
+        <?php
+        if (!empty($this->copyright)): ?>
+            Copyright: <strong><?= $this->copyright ?></strong><br/>
+        <?php
+        endif; ?>
 
-      <?php if ($this->canRecord === '1'): ?>
-         Allowed to record: <strong>Yes</strong>
-      <?php else: ?>
-         Allowed to record: <strong>No</strong>
-      <?php endif; ?>
-      <br/>
-      <?php if ($this->valid === '1'): ?>
-         Valid record: <strong>Yes</strong>
-      <?php else: ?>
-         Valid record: <strong>No</strong>
-      <?php endif; ?>
-      <br/>
-      <?php if (!empty($this->activationKey)): ?>
-         Activation key: <strong><?= $this->activationKey ?></strong>
-      <?php else: ?>
-         Activation key: 
-      <?php endif; ?>
-   </p>
+        <?php
+        if ($this->canRecord === '1'): ?>
+            Allowed to record: <strong>Yes</strong>
+        <?php
+        else: ?>
+            Allowed to record: <strong>No</strong>
+        <?php
+        endif; ?>
+        <br/>
+        <?php
+        if ($this->valid === '1'): ?>
+            Valid record: <strong>Yes</strong>
+        <?php
+        else: ?>
+            Valid record: <strong>No</strong>
+        <?php
+        endif; ?>
+        <br/>
+        <?php
+        if (!empty($this->activationKey)): ?>
+            Activation key: <strong><?= $this->activationKey ?></strong>
+        <?php
+        else: ?>
+            Activation key:
+        <?php
+        endif; ?>
+    </p>
 
-   <?php if (isset($this->researchOutline)) { ?>
-   <h3 class="lead">Research data</h3>
+    <?php
+    if (isset($this->researchOutline)) { ?>
+        <h3 class="lead">Research data</h3>
 
-   <p>Research outline: <strong><?= $this->researchOutline ?></strong></p>
-   <?php
-      }
-   ?>
+        <p>Research outline: <strong><?= $this->researchOutline ?></strong></p>
+        <?php
+    }
+    ?>
 </div>
 <h3 class="lead">Audit data</h3>
 <p>
-   <?php if (!is_null($this->creator)): ?>
-      Created by: <strong><?= $this->creator ?></strong>
-   <?php else: ?>
-      Themselves
-   <?php endif; ?>
-   <?php if (!is_null($this->updater)): ?><br/>
-      Last updated by: <strong><?= $this->updater ?></strong>
-   <?php endif; ?>
- </p>
+    <?php
+    if (!is_null($this->creator)): ?>
+        Created by: <strong><?= $this->creator ?></strong>
+    <?php
+    else: ?>
+        Themselves
+    <?php
+    endif; ?>
+    <?php
+    if (!is_null($this->updater)): ?><br/>
+        Last updated by: <strong><?= $this->updater ?></strong>
+    <?php
+    endif; ?>
+</p>
 <?= $this->searchLink()->setField('createdBy')->setId($this->id)->setUsername($this->username) ?>

--- a/app/views/scripts/partials/admin/account.phtml
+++ b/app/views/scripts/partials/admin/account.phtml
@@ -102,4 +102,4 @@
       Last updated by: <strong><?= $this->updater ?></strong>
    <?php endif; ?>
  </p>
-<?= $this->searchLink()->setField('createdBy')->setId($this->id) ?>
+<?= $this->searchLink()->setField('createdBy')->setId($this->id)->setUsername($this->username) ?>

--- a/library/Pas/View/Helper/SearchLink.php
+++ b/library/Pas/View/Helper/SearchLink.php
@@ -2,27 +2,26 @@
 
 /**
  * A view helper for setting up a search link
- *
  * An example of use:
- *
  * <code>
  * <?php
  * echo $this->searchLink()->setId($id);
  * ?>
  * </code>
  *
- * @author Daniel Pett <dpett at britishmuseum.org>
- * @category Pas
- * @package View
+ * @author     Daniel Pett <dpett at britishmuseum.org>
+ * @category   Pas
+ * @package    View
  * @subpackage Helper
- * @version 1
- * @example /app/modules/database/views/scripts/terminology/preservation.phtml
- * @todo Probably get rid of this!
+ * @version    1
+ * @example    /app/modules/database/views/scripts/terminology/preservation.phtml
+ * @todo       Probably get rid of this!
  */
 class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
 {
 
     /** Id number to query
+     *
      * @access protected
      * @var int
      */
@@ -32,12 +31,14 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     protected $_username;
 
     /** The page parameter
+     *
      * @access public
      * @var string
      */
     protected $_parameter;
 
     /** Get the parameter
+     *
      * @access public
      * @return string
      */
@@ -55,14 +56,15 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
 
     public function getField()
     {
-        if (is_null($this->_field)){
+        if (is_null($this->_field)) {
             return $this->getParameter();
-    } else {
-        return $this->_field;
-    }
+        } else {
+            return $this->_field;
+        }
     }
 
     /** Get the id to query
+     *
      * @access public
      * @return int
      */
@@ -72,6 +74,7 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     }
 
     /** Set the id number
+     *
      * @access public
      * @param int $id
      * @return \Pas_View_Helper_SearchLink
@@ -83,6 +86,7 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     }
 
     /** Get the username
+     *
      * @access public
      * @return string
      */
@@ -92,6 +96,7 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     }
 
     /** Set the username
+     *
      * @access public
      * @param string username
      * @return \Pas_View_Helper_SearchLink
@@ -103,6 +108,7 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     }
 
     /** Function to return
+     *
      * @access public
      * @return \Pas_View_Helper_SearchLink
      */
@@ -112,18 +118,22 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     }
 
     /** To string function
+     *
      * @access public
      * @return string
      */
     public function __toString()
     {
-        $url = $this->view->url(array(
+        $url = $this->view->url(
+            array(
                 'module' => 'database',
                 'controller' => 'search',
                 'action' => 'results',
                 $this->getField() => urlencode($this->getId())
             ),
-            null, true);
+            null,
+            true
+        );
 
         $string = '<p>Search the database for <a href="';
         $string .= $url;

--- a/library/Pas/View/Helper/SearchLink.php
+++ b/library/Pas/View/Helper/SearchLink.php
@@ -29,6 +29,7 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
     protected $_id;
 
     protected $_field;
+    protected $_username;
 
     /** The page parameter
      * @access public
@@ -81,6 +82,26 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
         return $this;
     }
 
+    /** Get the username
+     * @access public
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->_username;
+    }
+
+    /** Set the username
+     * @access public
+     * @param string username
+     * @return \Pas_View_Helper_SearchLink
+     */
+    public function setUsername($username)
+    {
+        $this->_username = $username;
+        return $this;
+    }
+
     /** Function to return
      * @access public
      * @return \Pas_View_Helper_SearchLink
@@ -107,7 +128,9 @@ class Pas_View_Helper_SearchLink extends Zend_View_Helper_Abstract
         $string = '<p>Search the database for <a href="';
         $string .= $url;
         $string .= '" title="Search the database for examples">all examples</a>';
-        $string .= ' recorded.</p>';
+        $string .= ' created by ' . $this->getUsername() . '</p>';
+
+
         return $string;
     }
 }


### PR DESCRIPTION
- Link "Search database for all examples recorded" can be confused
   to be all records linked to user rather than created
 - Wording changed to be clearer of the purpose of the link