### PR TITLE
61449 Missing regions from roman coin export

### DIFF
--- a/app/models/Finds.php
+++ b/app/models/Finds.php
@@ -2241,8 +2241,8 @@ class Finds extends Pas_Db_Table_Abstract
                 array('geography' => new Zend_Db_Expr("CONCAT(geographyironage.region,',',area)")))
             ->joinLeft('moneyers', 'coins.moneyer = moneyers.id',
                 array('moneyerName' => 'name', 'moneyerViaf' => 'viaf', 'moneyerBM' => 'bmID'))
-            ->joinLeft('regions', 'findspots.regionID = regions.id',
-                array('regionName' => 'region'))
+            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
+                array('regionName' => 'label'))
             ->joinLeft('people', 'finds.finderID = people.secuid',
                 array('finder' => 'fullname'))
             ->joinLeft('jettonClasses', 'coins.jettonClass = jettonClasses.id', array('jettonClass' => 'className'))
@@ -2252,6 +2252,9 @@ class Finds extends Pas_Db_Table_Abstract
             ->joinLeft(array('recorder' => 'people'),
                 'finds.recorderID =recorder.secuid',
                 array('recorder' => 'fullname'))
+            ->joinLeft('certaintytypes', 'certaintytypes.id = finds.objecttypecert',
+                array('objectCertainty' => 'term',
+                      'objectCertaintyID' => 'id'))
             ->where('finds.id = ?', (int)$findID)
             ->group('finds.id')
             ->limit(1);

--- a/app/models/Finds.php
+++ b/app/models/Finds.php
@@ -2,9 +2,7 @@
 
 /** Access, manipulate and delete finds data. I wrote this when I was
  * a naive new php programmer (still am really!). It sucks in a massive way.
- *
  * An example of use:
- *
  * <code>
  * <?php
  * $model = new Finds();
@@ -12,53 +10,58 @@
  * ?>
  * </code>
  *
- * @author Daniel Pett <dpett at britishmuseum.org>
+ * @author        Daniel Pett <dpett at britishmuseum.org>
  * @copyright (c) 2014 Daniel Pett
- * @category Pas
- * @package Db_Table
- * @subpackage Abstract
- * @author Mary Chester-Kadwell <mchester-kadwell@britishmuseum.org>
- * @copyright 2010 - DEJ Pett
- * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
- * @version 1
- * @since 22 September 2011
- * @todo needs a complete overhaul. Lots of duplication.
- * @example /app/modules/database/controllers/ArtefactsController.php
+ * @category      Pas
+ * @package       Db_Table
+ * @subpackage    Abstract
+ * @author        Mary Chester-Kadwell <mchester-kadwell@britishmuseum.org>
+ * @copyright     2010 - DEJ Pett
+ * @license       http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
+ * @version       1
+ * @since         22 September 2011
+ * @todo          needs a complete overhaul. Lots of duplication.
+ * @example       /app/modules/database/controllers/ArtefactsController.php
  */
 class Finds extends Pas_Db_Table_Abstract
 {
 
     /** The duplicate value error code
-     *
      */
     const DUPLICATE_UNIQUE_VALUE_ERROR_CODE = 23000;
     /** The table name
+     *
      * @access protected
      * @var string
      */
     protected $_name = 'finds';
     /** The primary key
+     *
      * @access protected
      * @var integer
      */
     protected $_primary = 'id';
     /** The higher level array
+     *
      * @access protected
      * @var array
      */
     protected $_higherlevel = array('admin', 'flos', 'fa', 'hero', 'treasure');
     /** The parish stop access
+     *
      * @access public
      * @var array
      */
     protected $_parishStop = array('admin', 'flos', 'fa', 'hero', 'treasure', 'research');
     /** The restricted access array
+     *
      * @access protected
      * @var array
      */
     protected $_restricted = array(null, 'public', 'member', 'research');
 
     /** Add a new find record
+     *
      * @param array
      * @return int
      */
@@ -92,7 +95,8 @@ class Finds extends Pas_Db_Table_Abstract
                     $writer = new Zend_Log_Writer_Stream('../app/logs/recordErrors.log');
                     $logger = new Zend_Log($writer);
                     $message = 'A problem was found ' . $code . ' was thrown';
-                    $message .= 'UserID: ' . $this->getUserNumber() . ' created this record ' . $insertData['old_findID'];
+                    $message .= 'UserID: ' . $this->getUserNumber(
+                        ) . ' created this record ' . $insertData['old_findID'];
                     $logger->err($message);
                     $i--;
                 } else { // Any other Zend_Db_Exception
@@ -108,6 +112,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Generates an old_findsID for new find records
+     *
      * @access    public
      * @return    string $findid The old_findsID
      * @throws  Pas_Exception_NotAuthorised
@@ -127,7 +132,7 @@ class Finds extends Pas_Db_Table_Abstract
 
     /** Edit a find record
      *
-     * @param array $updateData
+     * @param array   $updateData
      * @param integer $id
      * @return int
      */
@@ -135,7 +140,7 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $id2by = $updateData['id2by'];
         if ($id2by === "" || is_null($id2by)) {
-            $updateData['identifier2ID'] = NULL;
+            $updateData['identifier2ID'] = null;
         }
         unset($updateData['recordername']);
         unset($updateData['finder']);
@@ -165,7 +170,7 @@ class Finds extends Pas_Db_Table_Abstract
 
     /** Link a find record to a hoard record
      *
-     * @param array $updateData
+     * @param array   $updateData
      * @param integer $id
      * @return int
      */
@@ -177,17 +182,18 @@ class Finds extends Pas_Db_Table_Abstract
 
     /** Unlink a find record to a hoard record
      *
-     * @param array $updateData
+     * @param array   $updateData
      * @param integer $id
      * @return int
      */
     public function unlinkFind($id)
     {
         $where[0] = $this->getAdapter()->quoteInto('id = ?', $id);
-        return $this->update(array('hoardID' => NULL), $where);
+        return $this->update(array('hoardID' => null), $where);
     }
 
     /** Get a find's secure unique id for the jquery autocomplete
+     *
      * @access public
      * @param string $q
      * @return array
@@ -195,9 +201,13 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindSecuid($q)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'id' => 'secuid',
-                'term' => new Zend_Db_Expr("CONCAT(old_findID,' - ',objecttype,' ','(',broadperiod,')')")))
+            ->from(
+                $this->_name,
+                array(
+                    'id' => 'secuid',
+                    'term' => new Zend_Db_Expr("CONCAT(old_findID,' - ',objecttype,' ','(',broadperiod,')')")
+                )
+            )
             ->order($this->_primary)
             ->where('old_findID LIKE ?', (string)$q . '%')
             ->limit(10);
@@ -206,6 +216,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /**  Get a count of all the finds by specific workflow stage
+     *
      * @access public
      * @param integer $wfStageID
      * @return array
@@ -214,15 +225,18 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name, array('secwfstage'))
-            ->joinLeft('workflowstages',
+            ->joinLeft(
+                'workflowstages',
                 'finds.secwfstage = workflowstages.id',
-                array('workflowstage'))
+                array('workflowstage')
+            )
             ->where('finds.id = ?', (int)$wfStageID);
         $select->setIntegrityCheck(false);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Get massive data for a single record, loads of joins
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -230,124 +244,223 @@ class Finds extends Pas_Db_Table_Abstract
     public function getAllData($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'id',
-                'old_findID',
-                'uniqueID' => 'secuid',
-                'objecttype',
-                'classification',
-                'subclass',
-                'length',
-                'height',
-                'width',
-                'weight',
-                'thickness',
-                'diameter',
-                'quantity',
-                'otherRef' => 'other_ref',
-                'curr_loc',
-                'discoveryMethod' => 'discmethod',
-                'treasureID',
-                'broadperiod',
-                'numdate1',
-                'numdate2',
-                'description',
-                'notes',
-                'reuse',
-                'reusePeriodID' => 'reuse_period',
-                'created' => 'finds.created',
-                'broadperiod',
-                'updated',
-                'treasureID',
-                'secwfstage',
-                'findofnote',
-                'objecttypecert',
-                'datefound1',
-                'datefound2',
-                'inscription',
-                'disccircum',
-                'museumAccession' => 'musaccno',
-                'subsequentAction' => 'subs_action',
-                'objectCertainty' => 'objecttypecert',
-                'dateFromCertainty' => 'numdate1qual',
-                'dateToCertainty' => 'numdate2qual',
-                'dateFoundFromCertainty' => 'datefound1qual',
-                'dateFoundToCertainty' => 'datefound2qual',
-                'subPeriodFrom' => 'objdate1subperiod',
-                'subPeriodTo' => 'objdate2subperiod',
-                'objdate1period',
-                'objdate2period',
-                'secuid',
-                'material1',
-                'material2',
-                'manmethod',
-                'decmethod',
-                'decstyle',
-                'complete' => 'completeness',
-                'surface' => 'surftreat',
-                'manufactureID' => 'manmethod',
-                'culture',
-                'finderID',
-                'recorderID',
-                'identifier1ID',
-                'identifier2ID',
-                'smrRef' => 'smr_ref',
-                'createdBy',
-                'updatedBy',
-                'hoardcontainer',
-                'institution'
-            ))
-            ->joinLeft('findofnotereasons',
+            ->from(
+                $this->_name,
+                array(
+                    'id',
+                    'old_findID',
+                    'uniqueID' => 'secuid',
+                    'objecttype',
+                    'classification',
+                    'subclass',
+                    'length',
+                    'height',
+                    'width',
+                    'weight',
+                    'thickness',
+                    'diameter',
+                    'quantity',
+                    'otherRef' => 'other_ref',
+                    'curr_loc',
+                    'discoveryMethod' => 'discmethod',
+                    'treasureID',
+                    'broadperiod',
+                    'numdate1',
+                    'numdate2',
+                    'description',
+                    'notes',
+                    'reuse',
+                    'reusePeriodID' => 'reuse_period',
+                    'created' => 'finds.created',
+                    'broadperiod',
+                    'updated',
+                    'treasureID',
+                    'secwfstage',
+                    'findofnote',
+                    'objecttypecert',
+                    'datefound1',
+                    'datefound2',
+                    'inscription',
+                    'disccircum',
+                    'museumAccession' => 'musaccno',
+                    'subsequentAction' => 'subs_action',
+                    'objectCertainty' => 'objecttypecert',
+                    'dateFromCertainty' => 'numdate1qual',
+                    'dateToCertainty' => 'numdate2qual',
+                    'dateFoundFromCertainty' => 'datefound1qual',
+                    'dateFoundToCertainty' => 'datefound2qual',
+                    'subPeriodFrom' => 'objdate1subperiod',
+                    'subPeriodTo' => 'objdate2subperiod',
+                    'objdate1period',
+                    'objdate2period',
+                    'secuid',
+                    'material1',
+                    'material2',
+                    'manmethod',
+                    'decmethod',
+                    'decstyle',
+                    'complete' => 'completeness',
+                    'surface' => 'surftreat',
+                    'manufactureID' => 'manmethod',
+                    'culture',
+                    'finderID',
+                    'recorderID',
+                    'identifier1ID',
+                    'identifier2ID',
+                    'smrRef' => 'smr_ref',
+                    'createdBy',
+                    'updatedBy',
+                    'hoardcontainer',
+                    'institution'
+                )
+            )
+            ->joinLeft(
+                'findofnotereasons',
                 'finds.findofnotereason = findofnotereasons.id',
-                array('reason' => 'term'))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('username', 'fullname'))
-            ->joinLeft(array('users2' => 'users'), 'users2.id = finds.updatedBy',
+                array('reason' => 'term')
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('username', 'fullname')
+            )
+            ->joinLeft(
+                array('users2' => 'users'),
+                'users2.id = finds.updatedBy',
                 array(
                     'usernameUpdate' => 'username',
                     'fullnameUpdate' => 'fullname'
-                ))
-            ->joinLeft(array('mat' => 'materials'), 'finds.material1 = mat.id',
-                array('primaryMaterial' => 'term', 'primaryBMmaterial' => 'bmID'))
-            ->joinLeft(array('mat2' => 'materials'), 'finds.material2 = mat2.id',
-                array('secondaryMaterial' => 'term', 'secondaryBMmaterial' => 'bmID'))
-            ->joinLeft('decmethods', 'finds.decmethod = decmethods.id',
-                array('decoration' => 'term'))
-            ->joinLeft('decstyles', 'finds.decstyle = decstyles.id',
-                array('style' => 'term'))
-            ->joinLeft('manufactures', 'finds.manmethod = manufactures.id',
-                array('manufacture' => 'term'))
-            ->joinLeft('surftreatments', 'finds.surftreat = surftreatments.id',
-                array('surfaceTreatment' => 'term'))
-            ->joinLeft('completeness', 'finds.completeness = completeness.id',
-                array('completeness' => 'term'))
-            ->joinLeft('preservations', 'finds.preservation = preservations.id',
-                array('preservation' => 'term'))
-            ->joinLeft('certaintytypes', 'certaintytypes.id = finds.objecttypecert',
-                array('objectCertainty' => 'term'))
-            ->joinLeft('periods', 'finds.objdate1period = periods.id',
-                array('periodFrom' => 'term', 'seneschalPeriodFrom' => 'ehTerm', 'bmPeriodFrom' => 'bmID', 'periodoPeriodFrom' => 'periodo'))
-            ->joinLeft(array('p' => 'periods'), 'finds.objdate2period = p.id',
-                array('periodTo' => 'term', 'seneschalPeriodTo' => 'ehTerm', 'bmPeriodTo' => 'bmID', 'periodoPeriodTo' => 'periodo'))
-            ->joinLeft(array('p2' => 'periods'), 'finds.reuse_period = p2.id',
-                array('reusePeriod' => 'term'))
-            ->joinLeft('cultures', 'finds.culture = cultures.id',
-                array('ascribedCulture' => 'term', 'culturePeriodo' => 'periodo', 'cultureBM' => 'bmCultureID'))
-            ->joinLeft('discmethods', 'discmethods.id = finds.discmethod',
-                array('discmethod' => 'method'))
-            ->joinLeft('people', 'finds.finderID = people.secuid',
-                array('finder' => new Zend_Db_Expr("IF(people.title = 'Other', CONCAT(people.forename, ' ', people.surname),CONCAT(people.title, ' ', people.forename, ' ', people.surname))")))
-            ->joinLeft(array('ident1' => 'people'), 'finds.identifier1ID = ident1.secuid',
-                array('identifier' => new Zend_Db_Expr("IF(ident1.title = 'Other', CONCAT(ident1.forename, ' ', ident1.surname),CONCAT(ident1.title, ' ', ident1.forename, ' ', ident1.surname))")))
-            ->joinLeft(array('ident2' => 'people'), 'finds.identifier2ID = ident2.secuid',
-                array('secondaryIdentifier' => new Zend_Db_Expr("IF(ident2.title = 'Other', CONCAT(ident2.forename, ' ', ident2.surname), CONCAT(ident2.title, ' ', ident2.forename, ' ', ident2.surname))")))
-            ->joinLeft(array('record' => 'people'), 'finds.recorderID = record.secuid',
-                array('recorder' => new Zend_Db_Expr("IF(record.title = 'Other', CONCAT(record.forename, ' ', record.surname), CONCAT(record.title,' ', record.forename,' ', record.surname))")))
-            ->joinLeft(array('circa1' => 'datequalifiers'), $this->_name . '.numdate1qual = circa1.id',
-                array('fromCirca' => 'term'))
-            ->joinLeft(array('circa2' => 'datequalifiers'), $this->_name . '.numdate2qual = circa2.id',
-                array('toCirca' => 'term'))
-            ->joinLeft('findspots', 'finds.secuid = findspots.findID',
+                )
+            )
+            ->joinLeft(
+                array('mat' => 'materials'),
+                'finds.material1 = mat.id',
+                array('primaryMaterial' => 'term', 'primaryBMmaterial' => 'bmID')
+            )
+            ->joinLeft(
+                array('mat2' => 'materials'),
+                'finds.material2 = mat2.id',
+                array('secondaryMaterial' => 'term', 'secondaryBMmaterial' => 'bmID')
+            )
+            ->joinLeft(
+                'decmethods',
+                'finds.decmethod = decmethods.id',
+                array('decoration' => 'term')
+            )
+            ->joinLeft(
+                'decstyles',
+                'finds.decstyle = decstyles.id',
+                array('style' => 'term')
+            )
+            ->joinLeft(
+                'manufactures',
+                'finds.manmethod = manufactures.id',
+                array('manufacture' => 'term')
+            )
+            ->joinLeft(
+                'surftreatments',
+                'finds.surftreat = surftreatments.id',
+                array('surfaceTreatment' => 'term')
+            )
+            ->joinLeft(
+                'completeness',
+                'finds.completeness = completeness.id',
+                array('completeness' => 'term')
+            )
+            ->joinLeft(
+                'preservations',
+                'finds.preservation = preservations.id',
+                array('preservation' => 'term')
+            )
+            ->joinLeft(
+                'certaintytypes',
+                'certaintytypes.id = finds.objecttypecert',
+                array('objectCertainty' => 'term')
+            )
+            ->joinLeft(
+                'periods',
+                'finds.objdate1period = periods.id',
+                array(
+                    'periodFrom' => 'term',
+                    'seneschalPeriodFrom' => 'ehTerm',
+                    'bmPeriodFrom' => 'bmID',
+                    'periodoPeriodFrom' => 'periodo'
+                )
+            )
+            ->joinLeft(
+                array('p' => 'periods'),
+                'finds.objdate2period = p.id',
+                array(
+                    'periodTo' => 'term',
+                    'seneschalPeriodTo' => 'ehTerm',
+                    'bmPeriodTo' => 'bmID',
+                    'periodoPeriodTo' => 'periodo'
+                )
+            )
+            ->joinLeft(
+                array('p2' => 'periods'),
+                'finds.reuse_period = p2.id',
+                array('reusePeriod' => 'term')
+            )
+            ->joinLeft(
+                'cultures',
+                'finds.culture = cultures.id',
+                array('ascribedCulture' => 'term', 'culturePeriodo' => 'periodo', 'cultureBM' => 'bmCultureID')
+            )
+            ->joinLeft(
+                'discmethods',
+                'discmethods.id = finds.discmethod',
+                array('discmethod' => 'method')
+            )
+            ->joinLeft(
+                'people',
+                'finds.finderID = people.secuid',
+                array(
+                    'finder' => new Zend_Db_Expr(
+                        "IF(people.title = 'Other', CONCAT(people.forename, ' ', people.surname),CONCAT(people.title, ' ', people.forename, ' ', people.surname))"
+                    )
+                )
+            )
+            ->joinLeft(
+                array('ident1' => 'people'),
+                'finds.identifier1ID = ident1.secuid',
+                array(
+                    'identifier' => new Zend_Db_Expr(
+                        "IF(ident1.title = 'Other', CONCAT(ident1.forename, ' ', ident1.surname),CONCAT(ident1.title, ' ', ident1.forename, ' ', ident1.surname))"
+                    )
+                )
+            )
+            ->joinLeft(
+                array('ident2' => 'people'),
+                'finds.identifier2ID = ident2.secuid',
+                array(
+                    'secondaryIdentifier' => new Zend_Db_Expr(
+                        "IF(ident2.title = 'Other', CONCAT(ident2.forename, ' ', ident2.surname), CONCAT(ident2.title, ' ', ident2.forename, ' ', ident2.surname))"
+                    )
+                )
+            )
+            ->joinLeft(
+                array('record' => 'people'),
+                'finds.recorderID = record.secuid',
+                array(
+                    'recorder' => new Zend_Db_Expr(
+                        "IF(record.title = 'Other', CONCAT(record.forename, ' ', record.surname), CONCAT(record.title,' ', record.forename,' ', record.surname))"
+                    )
+                )
+            )
+            ->joinLeft(
+                array('circa1' => 'datequalifiers'),
+                $this->_name . '.numdate1qual = circa1.id',
+                array('fromCirca' => 'term')
+            )
+            ->joinLeft(
+                array('circa2' => 'datequalifiers'),
+                $this->_name . '.numdate2qual = circa2.id',
+                array('toCirca' => 'term')
+            )
+            ->joinLeft(
+                'findspots',
+                'finds.secuid = findspots.findID',
                 array(
                     'findSpotID' => 'id',
                     'countyID',
@@ -376,11 +489,16 @@ class Finds extends Pas_Db_Table_Abstract
                     'geonamesID',
                     'accuracy',
                     'what3words'
-                ))
-            ->joinLeft('gridrefsources',
+                )
+            )
+            ->joinLeft(
+                'gridrefsources',
                 'gridrefsources.ID = findspots.gridrefsrc',
-                array('source' => 'term'))
-            ->joinLeft('coins', 'finds.secuid = coins.findID',
+                array('source' => 'term')
+            )
+            ->joinLeft(
+                'coins',
+                'finds.secuid = coins.findID',
                 array(
                     'coinID' => 'id',
                     'obverseDescription' => 'obverse_description',
@@ -415,107 +533,203 @@ class Finds extends Pas_Db_Table_Abstract
                     'mintID' => 'mint_id',
                     'rrcID',
                     'ricID'
-                ))
+                )
+            )
             ->joinLeft('ironagetribes', 'coins.tribe = ironagetribes.id', array('tribe'))
-            ->joinLeft('geographyironage', 'geographyironage.id = coins.geographyID', array('ironAgeRegion' => 'region',
-                'ironAgeArea' => 'area'))
-            ->joinLeft('denominations', 'denominations.id = coins.denomination',
+            ->joinLeft(
+                'geographyironage',
+                'geographyironage.id = coins.geographyID',
+                array(
+                    'ironAgeRegion' => 'region',
+                    'ironAgeArea' => 'area'
+                )
+            )
+            ->joinLeft(
+                'denominations',
+                'denominations.id = coins.denomination',
                 array(
                     'denomination',
                     'nomismaDenomination' => 'nomismaID',
                     'dbpediaDenomination' => 'dbpediaID',
                     'bmDenomination' => 'bmID'
-                ))
-            ->joinLeft('rulers', 'rulers.id = coins.ruler_id',
+                )
+            )
+            ->joinLeft(
+                'rulers',
+                'rulers.id = coins.ruler_id',
                 array(
                     'primaryRuler' => 'issuer',
                     'viaf',
                     'rulerDbpedia' => 'dbpedia',
                     'nomismaRulerID' => 'nomismaID'
-                ))
-            ->joinLeft(array('rulers_2' => 'rulers'),
+                )
+            )
+            ->joinLeft(
+                array('rulers_2' => 'rulers'),
                 'rulers_2.id = coins.ruler2_id',
-                array('secondaryRuler' => 'issuer'))
-            ->joinLeft('reeceperiods', 'coins.reeceID = reeceperiods.id',
-                array('periodName' => 'period_name', 'dateRange' => 'date_range'))
-            ->joinLeft('mints', 'mints.id = coins.mint_ID', array(
-                'mintName' => 'mint_name',
-                'nomismaMintID' => 'nomismaID',
-                'pleiadesID',
-                'mintGeonamesID' => 'geonamesID',
-                'mintWoeid' => 'woeid',
-                'mintOsID' => 'osID',
-                'mintGettyID' => 'gettyID',
-                'mintWoeID' => 'woeid',
-                'mintDbPediaID' => 'dbpediaID',
-                'mintWhat3Words' => 'what3words',
-                'mintBritMuseumID' => 'bmID'
-            ))
-            ->joinLeft('weartypes', 'coins.degree_of_wear = weartypes.id', array('wear' => 'term',
-                'nomismaWear' => 'nomismaID'))
-            ->joinLeft('dieaxes', 'coins.die_axis_measurement = dieaxes.id',
-                array('dieAxisName' => 'die_axis_name'))
-            ->joinLeft('medievalcategories',
+                array('secondaryRuler' => 'issuer')
+            )
+            ->joinLeft(
+                'reeceperiods',
+                'coins.reeceID = reeceperiods.id',
+                array('periodName' => 'period_name', 'dateRange' => 'date_range')
+            )
+            ->joinLeft(
+                'mints',
+                'mints.id = coins.mint_ID',
+                array(
+                    'mintName' => 'mint_name',
+                    'nomismaMintID' => 'nomismaID',
+                    'pleiadesID',
+                    'mintGeonamesID' => 'geonamesID',
+                    'mintWoeid' => 'woeid',
+                    'mintOsID' => 'osID',
+                    'mintGettyID' => 'gettyID',
+                    'mintWoeID' => 'woeid',
+                    'mintDbPediaID' => 'dbpediaID',
+                    'mintWhat3Words' => 'what3words',
+                    'mintBritMuseumID' => 'bmID'
+                )
+            )
+            ->joinLeft(
+                'weartypes',
+                'coins.degree_of_wear = weartypes.id',
+                array(
+                    'wear' => 'term',
+                    'nomismaWear' => 'nomismaID'
+                )
+            )
+            ->joinLeft(
+                'dieaxes',
+                'coins.die_axis_measurement = dieaxes.id',
+                array('dieAxisName' => 'die_axis_name')
+            )
+            ->joinLeft(
+                'medievalcategories',
                 'medievalcategories.id = coins.categoryID',
-                array('category'))
-            ->joinLeft('medievaltypes', 'medievaltypes.id = coins.typeID',
-                array('type'))
-            ->joinLeft('moneyers', 'moneyers.id = coins.moneyer',
-                array('moneyer' => 'name', 'moneyerID' => 'id', 'nomismaMoneyer' => 'nomismaID'))
-            ->joinLeft('emperors', 'emperors.pasID = rulers.id',
-                array('emperorID' => 'id'))
-            ->joinLeft('romanmints', 'romanmints.pasID = mints.id',
-                array('romanMintID' => 'id'))
-            ->joinLeft('revtypes', 'coins.revtypeID = revtypes.id',
-                array('reverseType' => 'type'))
-            ->joinLeft('statuses', 'coins.status = statuses.id',
-                array('status' => 'term'))
+                array('category')
+            )
+            ->joinLeft(
+                'medievaltypes',
+                'medievaltypes.id = coins.typeID',
+                array('type')
+            )
+            ->joinLeft(
+                'moneyers',
+                'moneyers.id = coins.moneyer',
+                array('moneyer' => 'name', 'moneyerID' => 'id', 'nomismaMoneyer' => 'nomismaID')
+            )
+            ->joinLeft(
+                'emperors',
+                'emperors.pasID = rulers.id',
+                array('emperorID' => 'id')
+            )
+            ->joinLeft(
+                'romanmints',
+                'romanmints.pasID = mints.id',
+                array('romanMintID' => 'id')
+            )
+            ->joinLeft(
+                'revtypes',
+                'coins.revtypeID = revtypes.id',
+                array('reverseType' => 'type')
+            )
+            ->joinLeft(
+                'statuses',
+                'coins.status = statuses.id',
+                array('status' => 'term')
+            )
             ->joinLeft('jettonClasses', 'coins.jettonClass = jettonClasses.id', array('jettonClass' => 'className'))
             ->joinLeft('jettonTypes', 'coins.jettonType = jettonTypes.id', array('jettonType' => 'typeName'))
             ->joinLeft('jettonGroup', 'coins.jettonGroup = jettonGroup.id', array('jettonGroup' => 'groupName'))
-            ->joinLeft('finds_images', 'finds.secuid = finds_images.find_id',
-                array())
-            ->joinLeft('slides', 'slides.secuid = finds_images.image_id',
-                array('thumbnail' => 'imageID',
+            ->joinLeft(
+                'finds_images',
+                'finds.secuid = finds_images.find_id',
+                array()
+            )
+            ->joinLeft(
+                'slides',
+                'slides.secuid = finds_images.image_id',
+                array(
+                    'thumbnail' => 'imageID',
                     'filename',
                     'filesize',
                     'imageLabel' => 'label',
                     'imageCopyrightHolder' => 'imagerights',
                     'imageLicense' => 'ccLicense'
-                    ))
-            ->joinLeft(array('u' => 'users'), 'slides.createdBy = u.id',
+                )
+            )
+            ->joinLeft(
+                array('u' => 'users'),
+                'slides.createdBy = u.id',
                 array('imagedir')
             )
             ->joinLeft('regions', 'findspots.regionID = regions.id', array('region'))
-            ->joinLeft('rallies', 'rallies.id = finds.rallyID',
+            ->joinLeft(
+                'rallies',
+                'rallies.id = finds.rallyID',
                 array(
-                    'rallyID' => 'id', 'rallyName' => 'rally_name',
-                    'rallyDateFrom' => 'date_from', 'rallyDateTo' => 'date_to')
+                    'rallyID' => 'id',
+                    'rallyName' => 'rally_name',
+                    'rallyDateFrom' => 'date_from',
+                    'rallyDateTo' => 'date_to'
+                )
             )
-            ->joinLeft(array('land1' => 'landuses'),
+            ->joinLeft(
+                array('land1' => 'landuses'),
                 'land1.id = findspots.landusecode',
-                array('landuse' => 'term'))
-            ->joinLeft(array('land2' => 'landuses'),
+                array('landuse' => 'term')
+            )
+            ->joinLeft(
+                array('land2' => 'landuses'),
                 'land2.id = findspots.landusevalue',
-                array('landvalue' => 'term'))
-            ->joinLeft('maporigins', 'maporigins.id = findspots.gridrefsrc',
-                array('source' => 'term'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('regionType' => 'type', 'region' => 'label'))
-            ->joinLeft('osCounties', 'findspots.countyID = osCounties.osID',
-                array('countyType' => 'type', 'county' => 'label'))
-            ->joinLeft('osDistricts', 'findspots.districtID = osDistricts.osID',
-                array('districtType' => 'type', 'district' => 'label'))
-            ->joinLeft('osParishes', 'findspots.parishID = osParishes.osID',
+                array('landvalue' => 'term')
+            )
+            ->joinLeft(
+                'maporigins',
+                'maporigins.id = findspots.gridrefsrc',
+                array('source' => 'term')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('regionType' => 'type', 'region' => 'label')
+            )
+            ->joinLeft(
+                'osCounties',
+                'findspots.countyID = osCounties.osID',
+                array('countyType' => 'type', 'county' => 'label')
+            )
+            ->joinLeft(
+                'osDistricts',
+                'findspots.districtID = osDistricts.osID',
+                array('districtType' => 'type', 'district' => 'label')
+            )
+            ->joinLeft(
+                'osParishes',
+                'findspots.parishID = osParishes.osID',
                 array(
                     'parishType' => 'type',
                     'centreLat' => 'lat',
                     'centreLon' => 'lon',
                     'parish' => 'label'
-                ))
-            ->joinLeft(array('landowners' => 'people'), 'findspots.landowner = landowners.secuid', array('landOwnerName' => 'fullname', 'landOwnerID' => 'id'))
-            ->joinLeft('subsequentActions', 'finds.subs_action = subsequentActions.id', array('subsequentActionTerm' => 'action'))
-            ->joinLeft('objectterms', 'finds.objecttype = objectterms.term', array('bmThesObject' => 'bmID', 'seneschalObject' => 'ehID'))
+                )
+            )
+            ->joinLeft(
+                array('landowners' => 'people'),
+                'findspots.landowner = landowners.secuid',
+                array('landOwnerName' => 'fullname', 'landOwnerID' => 'id')
+            )
+            ->joinLeft(
+                'subsequentActions',
+                'finds.subs_action = subsequentActions.id',
+                array('subsequentActionTerm' => 'action')
+            )
+            ->joinLeft(
+                'objectterms',
+                'finds.objecttype = objectterms.term',
+                array('bmThesObject' => 'bmID', 'seneschalObject' => 'ehID')
+            )
             ->where('finds.id = ?', (int)$findID)
             ->group('finds.id')
             ->limit(1);
@@ -524,6 +738,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get dimensional data for a find
+     *
      * @param integer $findID the find number
      * @return array
      * @todo cache the output
@@ -531,16 +746,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindData($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'length', 'height', 'width',
-                'thickness', 'diameter', 'quantity',
-                'weight'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'length',
+                    'height',
+                    'width',
+                    'thickness',
+                    'diameter',
+                    'quantity',
+                    'weight'
+                )
+            )
             ->where('finds.id = ?', (int)$findID);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Get reference data for a find
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -548,15 +771,21 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindOtherRefs($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'other_ref', 'treasureID', 'smr_ref',
-                'musaccno'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'other_ref',
+                    'treasureID',
+                    'smr_ref',
+                    'musaccno'
+                )
+            )
             ->where('finds.id = ?', (int)$findID);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Get materials and manufacturing data for a find
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -564,27 +793,58 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindMaterials($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'material1', 'material2', 'manmethod',
-                'decmethod', 'decstyle', 'completeness',
-                'surftreat'
-            ))
-            ->joinLeft(array('mat' => 'materials'), 'finds.material1 = mat.id',
-                array('mat1' => 'term'))
-            ->joinLeft(array('mat2' => 'materials'), 'finds.material2 = mat2.id',
-                array('mat2' => 'term'))
-            ->joinLeft('decmethods', 'finds.decmethod = decmethods.id',
-                array('decoration' => 'term'))
-            ->joinLeft('decstyles', 'finds.decstyle = decstyles.id',
-                array('style' => 'term'))
-            ->joinLeft('manufactures', 'finds.manmethod = manufactures.id',
-                array('manufacture' => 'term'))
-            ->joinLeft('surftreatments', 'finds.surftreat = surftreatments.id',
-                array('surface' => 'term'))
-            ->joinLeft('completeness', 'finds.completeness = completeness.id',
-                array('complete' => 'term'))
-            ->joinLeft('certaintytypes', 'certaintytypes.id = finds.objecttypecert',
-                array('cert' => 'term'))
+            ->from(
+                $this->_name,
+                array(
+                    'material1',
+                    'material2',
+                    'manmethod',
+                    'decmethod',
+                    'decstyle',
+                    'completeness',
+                    'surftreat'
+                )
+            )
+            ->joinLeft(
+                array('mat' => 'materials'),
+                'finds.material1 = mat.id',
+                array('mat1' => 'term')
+            )
+            ->joinLeft(
+                array('mat2' => 'materials'),
+                'finds.material2 = mat2.id',
+                array('mat2' => 'term')
+            )
+            ->joinLeft(
+                'decmethods',
+                'finds.decmethod = decmethods.id',
+                array('decoration' => 'term')
+            )
+            ->joinLeft(
+                'decstyles',
+                'finds.decstyle = decstyles.id',
+                array('style' => 'term')
+            )
+            ->joinLeft(
+                'manufactures',
+                'finds.manmethod = manufactures.id',
+                array('manufacture' => 'term')
+            )
+            ->joinLeft(
+                'surftreatments',
+                'finds.surftreat = surftreatments.id',
+                array('surface' => 'term')
+            )
+            ->joinLeft(
+                'completeness',
+                'finds.completeness = completeness.id',
+                array('complete' => 'term')
+            )
+            ->joinLeft(
+                'certaintytypes',
+                'certaintytypes.id = finds.objecttypecert',
+                array('cert' => 'term')
+            )
             ->where('finds.id = ?', (int)$findID)
             ->group('finds.id')
             ->limit(1);
@@ -593,6 +853,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get temporal data for a find
+     *
      * @param integer $findID the find number
      * @return array
      * @todo cache the output
@@ -600,28 +861,46 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindTemporalData($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'broadperiod',
-                'numdate1',
-                'numdate2',
-                'period1' => 'objdate1period',
-                'period2' => 'objdate2period',
-                'culture',
-                'subPeriodFrom' => 'objdate1subperiod',
-                'subPeriodTo' => 'objdate2subperiod'
-            ))
-            ->joinLeft('periods', 'finds.objdate1period = periods.id',
-                array('term'))
-            ->joinLeft(array('p' => 'periods'), 'finds.objdate2period = p.id',
-                array('t2' => 'term'))
-            ->joinLeft('cultures', 'finds.culture = cultures.id',
-                array('cult' => 'term'))
-            ->joinLeft(array('circa1' => 'datequalifiers'), $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'broadperiod',
+                    'numdate1',
+                    'numdate2',
+                    'period1' => 'objdate1period',
+                    'period2' => 'objdate2period',
+                    'culture',
+                    'subPeriodFrom' => 'objdate1subperiod',
+                    'subPeriodTo' => 'objdate2subperiod'
+                )
+            )
+            ->joinLeft(
+                'periods',
+                'finds.objdate1period = periods.id',
+                array('term')
+            )
+            ->joinLeft(
+                array('p' => 'periods'),
+                'finds.objdate2period = p.id',
+                array('t2' => 'term')
+            )
+            ->joinLeft(
+                'cultures',
+                'finds.culture = cultures.id',
+                array('cult' => 'term')
+            )
+            ->joinLeft(
+                array('circa1' => 'datequalifiers'),
+                $this->_name
                 . '.numdate1qual = circa1.id',
-                array('fromcirca' => 'term'))
-            ->joinLeft(array('circa2' => 'datequalifiers'), $this->_name
+                array('fromcirca' => 'term')
+            )
+            ->joinLeft(
+                array('circa2' => 'datequalifiers'),
+                $this->_name
                 . '.numdate2qual = circa2.id',
-                array('tocirca' => 'term'))
+                array('tocirca' => 'term')
+            )
             ->where('finds.id = ?', (int)$findID)
             ->group('finds.id')
             ->limit(1);
@@ -630,6 +909,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get personal data for a find
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -637,33 +917,52 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPersonalData($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'finderID', 'recorderID', 'identifier1ID',
-                'identifier2ID'
-            ))
-            ->joinLeft('people', 'finds.finderID = people.secuid',
+            ->from(
+                $this->_name,
+                array(
+                    'finderID',
+                    'recorderID',
+                    'identifier1ID',
+                    'identifier2ID'
+                )
+            )
+            ->joinLeft(
+                'people',
+                'finds.finderID = people.secuid',
                 array(
                     'tit1' => 'title',
                     'fore' => 'forename',
-                    'sur' => 'surname', 'secuid'
-                ))
-            ->joinLeft(array('identifier1' => 'people'),
-                'finds.identifier1ID = identifier1.secuid', array(
+                    'sur' => 'surname',
+                    'secuid'
+                )
+            )
+            ->joinLeft(
+                array('identifier1' => 'people'),
+                'finds.identifier1ID = identifier1.secuid',
+                array(
                     'tit2' => 'title',
                     'fore2' => 'forename',
                     'sur2' => 'surname'
-                ))
-            ->joinLeft(array('identifier2' => 'people'),
-                'finds.identifier2ID = identifier2.secuid', array(
+                )
+            )
+            ->joinLeft(
+                array('identifier2' => 'people'),
+                'finds.identifier2ID = identifier2.secuid',
+                array(
                     'tit5' => 'title',
                     'fore5' => 'forename',
-                    'sur5' => 'surname'))
-            ->joinLeft(array('recorder' => 'people'),
-                'finds.recorderID = recorder.secuid', array(
+                    'sur5' => 'surname'
+                )
+            )
+            ->joinLeft(
+                array('recorder' => 'people'),
+                'finds.recorderID = recorder.secuid',
+                array(
                     'tit3' => 'title',
                     'fore3' => 'forename',
                     'sur3' => 'surname'
-                ))
+                )
+            )
             ->where('finds.id = ?', $findID)
             ->group('finds.id')
             ->limit(1);
@@ -673,6 +972,7 @@ class Finds extends Pas_Db_Table_Abstract
 
 
     /** Get finds entered by user per quarter as a count and sum
+     *
      * @access public
      * @param integer $staffID
      * @return array
@@ -680,12 +980,15 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindsFloQuarter($staffID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'year' => 'EXTRACT(YEAR FROM finds.created)',
-                'artefacts' => 'SUM(quantity)',
-                'records' => 'COUNT(*)',
-                'quarter' => 'QUARTER(finds.created)'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'year' => 'EXTRACT(YEAR FROM finds.created)',
+                    'artefacts' => 'SUM(quantity)',
+                    'records' => 'COUNT(*)',
+                    'quarter' => 'QUARTER(finds.created)'
+                )
+            )
             ->joinLeft('staff', 'staff.dbaseID = finds.createdBy', array())
             ->where('staff.id = ?', (int)$staffID)
             ->order(array('year', 'quarter'))
@@ -696,19 +999,26 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get finds entered by user per broadperiod as a count and sum
+     *
      * @param integer $staffID The user's ID
      * @return array
      */
     public function getFindsFloPeriod($staffID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'artefacts' => 'SUM(quantity)',
-                'records' => 'COUNT(*)',
-                'broadperiod'
-            ))
-            ->joinLeft('staff', 'staff.dbaseID = finds.createdBy',
-                array('id' => 'dbaseID'))
+            ->from(
+                $this->_name,
+                array(
+                    'artefacts' => 'SUM(quantity)',
+                    'records' => 'COUNT(*)',
+                    'broadperiod'
+                )
+            )
+            ->joinLeft(
+                'staff',
+                'staff.dbaseID = finds.createdBy',
+                array('id' => 'dbaseID')
+            )
             ->where('broadperiod IS NOT NULL')
             ->where('staff.id = ?', (int)$staffID)
             ->group('broadperiod');
@@ -718,21 +1028,26 @@ class Finds extends Pas_Db_Table_Abstract
 
 
     /** Get all finds by a day
+     *
      * @access public
      * @return array
      */
     public function getFindsByDay()
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'createdOn' => 'DATE_FORMAT(finds.created,"%Y-%m-%d")'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'createdOn' => 'DATE_FORMAT(finds.created,"%Y-%m-%d")'
+                )
+            )
             ->group('createdOn');
         $select->setIntegrityCheck(false);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Get total for reports by date
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -741,10 +1056,13 @@ class Finds extends Pas_Db_Table_Abstract
     public function getReportTotals($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
             ->where('created >= ?', (string)$datefrom)
             ->where('date(created) <= ?', (string)$dateto);
         $select->setIntegrityCheck(false);
@@ -752,6 +1070,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get finds officer totals by fullname for reports by date
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -760,12 +1079,18 @@ class Finds extends Pas_Db_Table_Abstract
     public function getOfficerTotals($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('fullname', 'institution', 'id'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('fullname', 'institution', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('institution', 'fullname')
@@ -775,6 +1100,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institutional totals for reports by date
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -783,12 +1109,18 @@ class Finds extends Pas_Db_Table_Abstract
     public function getInstitutionTotals($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('institution')
@@ -798,6 +1130,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get broadperiod totals for reports by date
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -806,11 +1139,14 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPeriodTotals($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod'
+                )
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->group('broadperiod');
@@ -819,6 +1155,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get distinct finder totals for reports by date
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -828,11 +1165,18 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name, array())
-            ->joinLeft('people', 'people.secuid = finds.finderID', array(
-                'finders' => 'COUNT(DISTINCT(finderID))'
-            ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
+            ->joinLeft(
+                'people',
+                'people.secuid = finds.finderID',
+                array(
+                    'finders' => 'COUNT(DISTINCT(finderID))'
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('institution')
@@ -842,6 +1186,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get monthly count of finds found
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -850,8 +1195,15 @@ class Finds extends Pas_Db_Table_Abstract
     public function getAverageMonth($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array('records' => 'COUNT(finds.id)', 'finds' => 'SUM(quantity)', 'broadperiod',
-                'month' => 'EXTRACT(MONTH FROM created)'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'month' => 'EXTRACT(MONTH FROM created)'
+                )
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('month ASC')
@@ -861,6 +1213,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get discovery year for finds found between certain dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -869,12 +1222,15 @@ class Finds extends Pas_Db_Table_Abstract
     public function getYearFound($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod',
-                'year' => 'EXTRACT(YEAR FROM datefound1)'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'year' => 'EXTRACT(YEAR FROM datefound1)'
+                )
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('year ASC')
@@ -884,6 +1240,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get discovery method counts for finds found between certain dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -892,12 +1249,18 @@ class Finds extends Pas_Db_Table_Abstract
     public function getDiscoveryMethod($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('discmethods', 'discmethods.id = finds.discmethod',
-                array('discmethod' => 'method', 'id'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'discmethods',
+                'discmethods.id = finds.discmethod',
+                array('discmethod' => 'method', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('discmethod')
@@ -907,6 +1270,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get landuse counts for finds found between certain dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -915,14 +1279,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getLandUse($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
-            ->joinLeft('landuses', 'landuses.id = findspots.landusevalue',
-                array('landuse' => 'term'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
+            ->joinLeft(
+                'landuses',
+                'landuses.id = findspots.landusevalue',
+                array('landuse' => 'term')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('landuse')
@@ -932,6 +1306,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get landuse counts for finds found between certain dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -940,13 +1315,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPrecision($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array('precision' => 'gridlen'))
+                array('precision' => 'gridlen')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('precision')
@@ -956,6 +1337,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get landuse counts for finds found between certain dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -964,12 +1346,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getCounties($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array('county'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array('county')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('county')
@@ -979,6 +1368,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get counts for finds found between certain dates for counties
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -988,12 +1378,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getCountyStat($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array('county'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array('county')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1005,6 +1402,7 @@ class Finds extends Pas_Db_Table_Abstract
 
     /** Get counts for finds found between certain dates for counties by
      * specific user
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1014,16 +1412,25 @@ class Finds extends Pas_Db_Table_Abstract
     public function getUsersStat($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array())
-            ->joinLeft('users', $this->_name
+                array()
+            )
+            ->joinLeft(
+                'users',
+                $this->_name
                 . '.createdBy = users.id',
-                array('fullname', 'username', 'institution', 'id'))
+                array('fullname', 'username', 'institution', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1034,6 +1441,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get counts for finds found between certain dates for periods and county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1043,13 +1451,20 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPeriodTotalsCounty($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1059,6 +1474,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get counts for finders by county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1069,14 +1485,24 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name, array())
-            ->joinLeft('people', 'people.secuid = finds.finderID',
+            ->joinLeft(
+                'people',
+                'people.secuid = finds.finderID',
                 array(
                     'finders' => 'COUNT(DISTINCT(finderID))'
-                ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1087,6 +1513,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get finds per month by county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1096,15 +1523,21 @@ class Finds extends Pas_Db_Table_Abstract
     public function getAverageMonthCounty($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod',
-                'month' => 'EXTRACT(MONTH FROM ' . $this->_name . '.created)'
-            ))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'month' => 'EXTRACT(MONTH FROM ' . $this->_name . '.created)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array())
+                array()
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1115,23 +1548,31 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get finds per year by county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
-     * @param strig $county
+     * @param strig  $county
      * @return array
      */
     public function getYearFoundCounty($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod',
-                'year' => 'EXTRACT(YEAR FROM datefound1)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'year' => 'EXTRACT(YEAR FROM datefound1)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1142,6 +1583,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get discovery method totals by county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1151,14 +1593,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getDiscoveryMethodCounty($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
-            ->joinLeft('discmethods', 'discmethods.id = finds.discmethod',
-                array('discmethod' => 'method', 'id'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
+            ->joinLeft(
+                'discmethods',
+                'discmethods.id = finds.discmethod',
+                array('discmethod' => 'method', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('findspots.county = ?', (string)$county)
@@ -1169,6 +1621,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get landuse totals by county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1178,14 +1631,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getLandUseCounty($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
-            ->joinLeft('landuses', 'landuses.id = findspots.landusevalue',
-                array('landuse' => 'term', 'id'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
+            ->joinLeft(
+                'landuses',
+                'landuses.id = findspots.landusevalue',
+                array('landuse' => 'term', 'id')
+            )
             ->where('findspots.county = ?', (string)$county)
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1196,6 +1659,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get precision of findspot by county
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1205,13 +1669,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPrecisionCounty($datefrom, $dateto, $county)
     {
         $select = $this->select()
-            ->from($this->_name,
-                array('records' => 'COUNT(*)',
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
                     'finds' => 'SUM(quantity)'
-                ))
-            ->joinLeft('findspots', $this->_name
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array('precision' => 'gridlen'))
+                array('precision' => 'gridlen')
+            )
             ->where('findspots.county = ?', (string)$county)
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1222,6 +1692,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get recording institutions between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1230,14 +1701,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getInstitutions($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name,
+            ->from(
+                $this->_name,
                 array(
                     'records' => 'COUNT(*)',
                     'finds' => 'SUM(quantity)'
-                ))
-            ->joinLeft('users', $this->_name
+                )
+            )
+            ->joinLeft(
+                'users',
+                $this->_name
                 . '.createdBy = users.id',
-                array('institution'))
+                array('institution')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('institution')
@@ -1247,6 +1723,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get  institution's recording stats between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1256,13 +1733,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getInstStat($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('users', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                $this->_name
                 . '.createdBy = users.id',
-                array('institution'))
+                array('institution')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('users.institution = ?', (string)$institution)
@@ -1274,6 +1757,7 @@ class Finds extends Pas_Db_Table_Abstract
 
 
     /** Get institution's recording user stats between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1283,13 +1767,19 @@ class Finds extends Pas_Db_Table_Abstract
     public function getUsersInstStat($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('users', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                $this->_name
                 . '.createdBy = users.id',
-                array('fullname', 'username', 'institution', 'id'))
+                array('fullname', 'username', 'institution', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('users.institution = ?', (string)$institution)
@@ -1300,6 +1790,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's recording period totals between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1309,13 +1800,20 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPeriodTotalsInst($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)', 'broadperiod'
-            ))
-            ->joinLeft('users', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod'
+                )
+            )
+            ->joinLeft(
+                'users',
+                $this->_name
                 . '.createdBy = users.id',
-                array('fullname', 'username', 'institution', 'id'))
+                array('fullname', 'username', 'institution', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('users.institution = ?', (string)$institution)
@@ -1326,6 +1824,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's number of finders between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1336,8 +1835,11 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name, array())
-            ->joinLeft('people', 'people.secuid = finds.finderID',
-                array('finders' => 'COUNT(DISTINCT(finderID))'))
+            ->joinLeft(
+                'people',
+                'people.secuid = finds.finderID',
+                array('finders' => 'COUNT(DISTINCT(finderID))')
+            )
             ->joinLeft('users', 'users.id = finds.createdBy', array('institution'))
             ->where($this->_name . '.created >= ?', $datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1349,6 +1851,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's year of discovery range between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1358,14 +1861,20 @@ class Finds extends Pas_Db_Table_Abstract
     public function getYearFoundInst($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod',
-                'year' => 'EXTRACT(YEAR FROM datefound1)'
-            ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'year' => 'EXTRACT(YEAR FROM datefound1)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('users.institution = ?', (string)$institution)
@@ -1376,6 +1885,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's method of discovery range between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1385,14 +1895,23 @@ class Finds extends Pas_Db_Table_Abstract
     public function getDiscoveryMethodInst($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('discmethods', 'discmethods.id = finds.discmethod',
-                array('discmethod' => 'method'))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'discmethods',
+                'discmethods.id = finds.discmethod',
+                array('discmethod' => 'method')
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('users.institution = ?', (string)$institution)
@@ -1403,6 +1922,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's land uses range between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1412,17 +1932,29 @@ class Finds extends Pas_Db_Table_Abstract
     public function getLandUseInst($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array())
-            ->joinLeft('landuses', 'landuses.id = findspots.landusevalue',
-                array('landuse' => 'term', 'id'))
+                array()
+            )
+            ->joinLeft(
+                'landuses',
+                'landuses.id = findspots.landusevalue',
+                array('landuse' => 'term', 'id')
+            )
             ->where('users.institution = ?', (string)$institution)
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1433,6 +1965,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's land uses range between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1442,15 +1975,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getPrecisionInst($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array('precision' => 'gridlen'))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('institution'))
+                array('precision' => 'gridlen')
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('institution')
+            )
             ->where('users.institution = ?', (string)$institution)
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1461,6 +2003,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get institution's monthly records and sum recorded between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1470,14 +2013,20 @@ class Finds extends Pas_Db_Table_Abstract
     public function getAverageMonthInst($datefrom, $dateto, $institution)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod',
-                'month' => 'EXTRACT(MONTH FROM finds.created)'
-            ))
-            ->joinLeft('users', 'finds.createdBy = users.id',
-                array('fullname'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'month' => 'EXTRACT(MONTH FROM finds.created)'
+                )
+            )
+            ->joinLeft(
+                'users',
+                'finds.createdBy = users.id',
+                array('fullname')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('users.institution = ?', (string)$institution)
@@ -1488,6 +2037,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get recording regions between dates
+     *
      * @access public
      * @param string $datefrom
      * @param string $dateto
@@ -1496,15 +2046,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getRegions($datefrom, $dateto)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array())
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label', 'id' => 'osID'))
+                array()
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label', 'id' => 'osID')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->order('region')
@@ -1514,24 +2073,34 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get regions' figures between dates
+     *
      * @access public
-     * @param string $datefrom
-     * @param string $dateto
+     * @param string  $datefrom
+     * @param string  $dateto
      * @param integer $regionID
      * @return array
      */
     public function getRegionStat($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array('county'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label', 'id' => 'osID'))
+                array('county')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label', 'id' => 'osID')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('osRegions.osID= ?', (int)$regionID)
@@ -1542,25 +2111,39 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get users recording by a region between dates
+     *
      * @access public
-     * @param string $datefrom
-     * @param string $dateto
+     * @param string  $datefrom
+     * @param string  $dateto
      * @param integer $regionID
      * @return array
      */
     public function getUsersRegionStat($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label'))
-            ->joinLeft('users', $this->_name . '.createdBy = users.id',
-                array('fullname', 'username', 'institution', 'id'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label')
+            )
+            ->joinLeft(
+                'users',
+                $this->_name . '.createdBy = users.id',
+                array('fullname', 'username', 'institution', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('osRegions.osID = ?', (integer)$regionID)
@@ -1571,23 +2154,34 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get broadperiods by a region between dates
-     * @param string $datefrom The first date
-     * @param string $dateto The second date
+     *
+     * @param string  $datefrom The first date
+     * @param string  $dateto   The second date
      * @param integer $regionID The recording region
      * @return array
      */
     public function getPeriodTotalsRegion($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array())
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label', 'id' => 'osID'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array()
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label', 'id' => 'osID')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('osRegions.osID = ?', (integer)$regionID)
@@ -1598,9 +2192,10 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get finder totals by a region between dates
+     *
      * @access public
-     * @param string $datefrom
-     * @param string $dateto
+     * @param string  $datefrom
+     * @param string  $dateto
      * @param integer $regionID
      * @return array
      */
@@ -1608,15 +2203,27 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name, array())
-            ->joinLeft('people', 'people.secuid = finds.finderID',
-                array('finders' => 'COUNT(DISTINCT(finderID))'))
-            ->joinLeft('findspots', $this->_name
+            ->joinLeft(
+                'people',
+                'people.secuid = finds.finderID',
+                array('finders' => 'COUNT(DISTINCT(finderID))')
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
                 . '.secuid = findspots.findID',
-                array('county'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label'))
-            ->joinLeft('users', $this->_name . '.createdBy = users.id',
-                array('fullname', 'username', 'institution', 'id'))
+                array('county')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label')
+            )
+            ->joinLeft(
+                'users',
+                $this->_name . '.createdBy = users.id',
+                array('fullname', 'username', 'institution', 'id')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('osRegions.osID = ?', (string)$regionID)
@@ -1627,16 +2234,24 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get year of discovery by a region between dates
-     * @param string $datefrom The first date
-     * @param string $dateto The second date
+     *
+     * @param string  $datefrom The first date
+     * @param string  $dateto   The second date
      * @param integer $regionID The recording region
      * @return array
      */
     public function getYearFoundRegion($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array('records' => 'COUNT(*)', 'finds' => 'SUM(quantity)', 'broadperiod',
-                'year' => 'EXTRACT(YEAR FROM datefound1)'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'year' => 'EXTRACT(YEAR FROM datefound1)'
+                )
+            )
             ->joinLeft('findspots', $this->_name . '.secuid = findspots.findID', array('county'))
             ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID', array('region' => 'label', 'id' => 'osID'))
             ->where($this->_name . '.created >= ?', $datefrom)
@@ -1649,8 +2264,9 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get finder totals by a region between dates
-     * @param string $datefrom The first date
-     * @param string $dateto The second date
+     *
+     * @param string  $datefrom The first date
+     * @param string  $dateto   The second date
      * @param integer $regionID The recording region
      * @return array
      */
@@ -1671,24 +2287,38 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get landuse totals by a region between dates
-     * @param string $datefrom The first date
-     * @param string $dateto The second date
+     *
+     * @param string  $datefrom The first date
+     * @param string  $dateto   The second date
      * @param integer $regionID The recording region
      * @return array
      */
     public function getLandUseRegion($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array('county'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label'))
-            ->joinLeft('landuses', 'landuses.id = findspots.landusevalue',
-                array('landuse' => 'term'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array('county')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label')
+            )
+            ->joinLeft(
+                'landuses',
+                'landuses.id = findspots.landusevalue',
+                array('landuse' => 'term')
+            )
             ->where('osRegions.osID = ?', (integer)$regionID)
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1699,23 +2329,33 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get findspot precision by a region between dates
+     *
      * @access public
-     * @param string $datefrom
-     * @param string $dateto
+     * @param string  $datefrom
+     * @param string  $dateto
      * @param integer $regionID
      * @return array
      */
     public function getPrecisionRegion($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)'
-            ))
-            ->joinLeft('findspots', $this->_name . '.secuid = findspots.findID',
-                array('precision' => 'gridlen'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name . '.secuid = findspots.findID',
+                array('precision' => 'gridlen')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label')
+            )
             ->where('osRegions.osID = ?', (integer)$regionID)
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
@@ -1726,25 +2366,36 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get monthly totals by region between dates
+     *
      * @access public
-     * @param string $datefrom
-     * @param string $dateto
+     * @param string  $datefrom
+     * @param string  $dateto
      * @param integer $regionID
      * @return array
      */
     public function getAverageMonthRegion($datefrom, $dateto, $regionID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'records' => 'COUNT(*)',
-                'finds' => 'SUM(quantity)',
-                'broadperiod',
-                'month' => 'EXTRACT(MONTH FROM finds.created)'
-            ))
-            ->joinLeft('findspots', $this->_name
-                . '.secuid = findspots.findID', array('county'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('region' => 'label'))
+            ->from(
+                $this->_name,
+                array(
+                    'records' => 'COUNT(*)',
+                    'finds' => 'SUM(quantity)',
+                    'broadperiod',
+                    'month' => 'EXTRACT(MONTH FROM finds.created)'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                $this->_name
+                . '.secuid = findspots.findID',
+                array('county')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('region' => 'label')
+            )
             ->where($this->_name . '.created >= ?', (string)$datefrom)
             ->where('date(' . $this->_name . '.created) <= ?', (string)$dateto)
             ->where('osRegions.osID = ?', (integer)$regionID)
@@ -1755,6 +2406,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Check if a findspot exists
+     *
      * @access public
      * @param integer $findspotID
      * @return array
@@ -1763,14 +2415,18 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name)
-            ->joinLeft('findspots', 'finds.secuid = findspots.findID',
-                array())
+            ->joinLeft(
+                'findspots',
+                'finds.secuid = findspots.findID',
+                array()
+            )
             ->where('findspots.id = ?', (int)$findspotID);
         $select->setIntegrityCheck(false);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** get data for embedding a find
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -1778,26 +2434,46 @@ class Finds extends Pas_Db_Table_Abstract
     public function getEmbedFind($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'broadperiod', 'id', 'objecttype',
-                'old_findID'
-            ))
-            ->joinLeft('periods', 'finds.objdate1period = periods.id',
-                array('t' => 'term'))
-            ->joinLeft('findspots', 'finds.secuid = findspots.findID',
+            ->from(
+                $this->_name,
                 array(
-                    'gridref', 'easting', 'northing',
-                    'parish', 'county', 'regionID',
-                    'district', 'declat', 'declong',
-                    'smrref', 'map25k', 'map10k',
+                    'broadperiod',
+                    'id',
+                    'objecttype',
+                    'old_findID'
+                )
+            )
+            ->joinLeft(
+                'periods',
+                'finds.objdate1period = periods.id',
+                array('t' => 'term')
+            )
+            ->joinLeft(
+                'findspots',
+                'finds.secuid = findspots.findID',
+                array(
+                    'gridref',
+                    'easting',
+                    'northing',
+                    'parish',
+                    'county',
+                    'regionID',
+                    'district',
+                    'declat',
+                    'declong',
+                    'smrref',
+                    'map25k',
+                    'map10k',
                     'knownas'
-                ))
+                )
+            )
             ->where('finds.id= ?', (int)$findID);
         $select->setIntegrityCheck(false);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** gGt data for citation of a find
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -1805,25 +2481,37 @@ class Finds extends Pas_Db_Table_Abstract
     public function getWebCiteFind($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'broadperiod', 'id', 'objecttype',
-                'old_findID', 'created' => 'DATE_FORMAT(finds.created,"%Y")'
-            ))
-            ->joinLeft('periods', 'finds.objdate1period = periods.id',
-                array('t' => 'term'))
-            ->joinLeft(array('record' => 'people'),
+            ->from(
+                $this->_name,
+                array(
+                    'broadperiod',
+                    'id',
+                    'objecttype',
+                    'old_findID',
+                    'created' => 'DATE_FORMAT(finds.created,"%Y")'
+                )
+            )
+            ->joinLeft(
+                'periods',
+                'finds.objdate1period = periods.id',
+                array('t' => 'term')
+            )
+            ->joinLeft(
+                array('record' => 'people'),
                 'finds.recorderID = record.secuid',
                 array(
                     'tit3' => 'title',
                     'fore3' => 'forename',
                     'sur3' => 'surname'
-                ))
+                )
+            )
             ->where('finds.id= ?', (int)$findID);
         $select->setIntegrityCheck(false);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Retrieve edit data for a find
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -1832,20 +2520,31 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name)
-            ->joinLeft('people', 'finds.finderID = people.secuid',
-                array('finder' => 'fullname'))
-            ->joinLeft(array('people2' => 'people'),
+            ->joinLeft(
+                'people',
+                'finds.finderID = people.secuid',
+                array('finder' => 'fullname')
+            )
+            ->joinLeft(
+                array('people2' => 'people'),
                 'finds.finder2ID = people2.secuid',
-                array('secondfinder' => 'fullname'))
-            ->joinLeft(array('ident1' => 'people'),
+                array('secondfinder' => 'fullname')
+            )
+            ->joinLeft(
+                array('ident1' => 'people'),
                 'finds.identifier1ID = ident1.secuid',
-                array('idBy' => 'fullname'))
-            ->joinLeft(array('ident2' => 'people'),
+                array('idBy' => 'fullname')
+            )
+            ->joinLeft(
+                array('ident2' => 'people'),
                 'finds.identifier2ID = ident2.secuid',
-                array('id2by' => 'fullname'))
-            ->joinLeft(array('record' => 'people'),
+                array('id2by' => 'fullname')
+            )
+            ->joinLeft(
+                array('record' => 'people'),
                 'finds.recorderID = record.secuid',
-                array('recordername' => 'fullname'))
+                array('recordername' => 'fullname')
+            )
             ->where('finds.id = ?', (int)$findID)
             ->group('finds.id')
             ->limit(1);
@@ -1854,6 +2553,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Retrieve find's numbers and broadperiod
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -1861,16 +2561,22 @@ class Finds extends Pas_Db_Table_Abstract
     public function getFindNumbersEtc($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'objecttype', 'id', 'broadperiod',
-                'old_findID'
-            ))
+            ->from(
+                $this->_name,
+                array(
+                    'objecttype',
+                    'id',
+                    'broadperiod',
+                    'old_findID'
+                )
+            )
             ->where('finds.id = ?', (int)$findID)
             ->limit(1);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Retrieve finds adviser responsible
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -1878,13 +2584,24 @@ class Finds extends Pas_Db_Table_Abstract
     public function getRelevantAdviserFind($findID)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'objecttype', 'id', 'broadperiod',
-                'old_findID', 'secuid', 'institution',
-                'createdBy', 'created'
-            ))
-            ->joinLeft('findspots', 'finds.secuid = findspots.findID',
-                array('county'))
+            ->from(
+                $this->_name,
+                array(
+                    'objecttype',
+                    'id',
+                    'broadperiod',
+                    'old_findID',
+                    'secuid',
+                    'institution',
+                    'createdBy',
+                    'created'
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                'finds.secuid = findspots.findID',
+                array('county')
+            )
             ->where('finds.id = ?', (int)$findID)
             ->limit(1);
         $select->setIntegrityCheck(false);
@@ -1892,48 +2609,58 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Retrieve find data if allowed access
+     *
      * @access public
      * @param integer $findID
-     * @param string $role
+     * @param string  $role
      * @return array
      */
     public function getIndividualFind($findID, $role)
     {
         $select = $this->select()
-            ->from($this->_name, array(
-                'created2' => 'DATE_FORMAT(finds.created,"%Y %m %d")',
-                'description',
-                'notes',
-                'old_findID',
-                'id',
-                'objecttype',
-                'classification',
-                'subclass',
-                'reuse',
-                'created' => 'finds.created',
-                'broadperiod',
-                'updated',
-                'treasureID',
-                'secwfstage',
-                'secuid',
-                'findofnote',
-                'objecttypecert',
-                'datefound1',
-                'datefound2',
-                'createdBy',
-                'curr_loc',
-                'hoardcontainer',
-                'inscription',
-                'institution'))
-            ->joinLeft('findofnotereasons',
+            ->from(
+                $this->_name,
+                array(
+                    'created2' => 'DATE_FORMAT(finds.created,"%Y %m %d")',
+                    'description',
+                    'notes',
+                    'old_findID',
+                    'id',
+                    'objecttype',
+                    'classification',
+                    'subclass',
+                    'reuse',
+                    'created' => 'finds.created',
+                    'broadperiod',
+                    'updated',
+                    'treasureID',
+                    'secwfstage',
+                    'secuid',
+                    'findofnote',
+                    'objecttypecert',
+                    'datefound1',
+                    'datefound2',
+                    'createdBy',
+                    'curr_loc',
+                    'hoardcontainer',
+                    'inscription',
+                    'institution'
+                )
+            )
+            ->joinLeft(
+                'findofnotereasons',
                 'finds.findofnotereason = findofnotereasons.id',
-                array('reason' => 'term'))
-            ->joinLeft('subsequentActions',
+                array('reason' => 'term')
+            )
+            ->joinLeft(
+                'subsequentActions',
                 'finds.subs_action = subsequentActions.id',
-                array('subsequentAction' => 'action'))
+                array('subsequentAction' => 'action')
+            )
             ->where('finds.id= ?', (int)$findID);
         if (in_array($role, $this->_restricted)) {
-            $select->where(new Zend_Db_Expr(
+            $select->where(
+                new Zend_Db_Expr(
                     'finds.secwfstage IN ( 3, 4) OR finds.createdBy = '
                     . (int)$this->getUserNumber()
                 )
@@ -1944,6 +2671,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get attached images
+     *
      * @access public
      * @param integer $id
      * @return array
@@ -1952,19 +2680,30 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $key = md5('findtoimage' . $id);
         if (!$data = $this->_cache->load($key)) {
-
             $select = $this->select()
-                ->from($this->_name, array(
-                    'old_findID', 'broadperiod', 'objecttype'
-                ))
-                ->joinLeft('users', 'users.id = finds.createdBy',
-                    array('imagedir'))
-                ->joinLeft('finds_images',
+                ->from(
+                    $this->_name,
+                    array(
+                        'old_findID',
+                        'broadperiod',
+                        'objecttype'
+                    )
+                )
+                ->joinLeft(
+                    'users',
+                    'users.id = finds.createdBy',
+                    array('imagedir')
+                )
+                ->joinLeft(
+                    'finds_images',
                     'finds.secuid = finds_images.find_id',
-                    array())
-                ->joinLeft('slides',
+                    array()
+                )
+                ->joinLeft(
+                    'slides',
                     'slides.secuid = finds_images.image_id',
-                    array('i' => 'imageID', 'f' => 'filename'))
+                    array('i' => 'imageID', 'f' => 'filename')
+                )
                 ->where('finds.id= ?', (int)$id)
                 ->order('slides.imageID ASC')
                 ->limit(1);
@@ -1976,6 +2715,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get the last record created by a specific user
+     *
      * @access public
      * @param integer $userid
      * @return array
@@ -1986,21 +2726,31 @@ class Finds extends Pas_Db_Table_Abstract
         $fields = $fieldList->getConfig();
         $select = $this->select()
             ->from($this->_name, $fields)
-            ->joinLeft(array('finderOne' => 'people'),
+            ->joinLeft(
+                array('finderOne' => 'people'),
                 'finderOne.secuid = finds.finderID',
-                array('finder' => 'fullname'))
-            ->joinLeft(array('finderTwo' => 'people'),
+                array('finder' => 'fullname')
+            )
+            ->joinLeft(
+                array('finderTwo' => 'people'),
                 'finderTwo.secuid = finds.finder2ID',
-                array('secondfinder' => 'fullname'))
-            ->joinLeft(array('identifier' => 'people'),
+                array('secondfinder' => 'fullname')
+            )
+            ->joinLeft(
+                array('identifier' => 'people'),
                 'identifier.secuid = finds.identifier1ID',
-                array('idby' => 'fullname'))
-            ->joinLeft(array('identifierTwo' => 'people'),
+                array('idby' => 'fullname')
+            )
+            ->joinLeft(
+                array('identifierTwo' => 'people'),
                 'identifierTwo.secuid = finds.identifier2ID',
-                array('id2by' => 'fullname'))
-            ->joinLeft(array('recorder' => 'people'),
+                array('id2by' => 'fullname')
+            )
+            ->joinLeft(
+                array('recorder' => 'people'),
                 'recorder.secuid = finds.finderID',
-                array('recordername' => 'fullname'))
+                array('recordername' => 'fullname')
+            )
             ->where('finds.createdBy = ?', (int)$userid)
             ->order('finds.id DESC')
             ->limit(1);
@@ -2009,6 +2759,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Get findID and secuid for linking images
+     *
      * @access public
      * @param string $q
      * @return array
@@ -2024,6 +2775,7 @@ class Finds extends Pas_Db_Table_Abstract
 
 
     /** Get creator of a record by ID number
+     *
      * @access public
      * @param integer $findID
      * @return array
@@ -2032,23 +2784,28 @@ class Finds extends Pas_Db_Table_Abstract
     {
         $select = $this->select()
             ->from($this->_name, array('old_findID', 'objecttype'))
-            ->joinLeft('users', 'users.id = finds.createdBy',
-                array('email', 'fullname'))
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
+                array('email', 'fullname')
+            )
             ->where('finds.id = ?', (int)$findID);
         $select->setIntegrityCheck(false);
         return $this->getAdapter()->fetchAll($select);
     }
 
     /** Retrieve record data in format for solr schema
+     *
      * @access public
      * @param integer $findID
      * @return array
      */
-    public function getSolrData($findID, $type = NULL)
+    public function getSolrData($findID, $type = null)
     {
         $findsdata = $this->getAdapter();
         $select = $findsdata->select()
-            ->from($this->_name,
+            ->from(
+                $this->_name,
                 array(
                     'findIdentifier' => new Zend_Db_Expr("CONCAT('finds-',finds.id)"),
                     'id',
@@ -2103,8 +2860,11 @@ class Finds extends Pas_Db_Table_Abstract
                     'recorderID',
                     'identifierID' => 'identifier1ID',
                     'createdBy'
-                ))
-            ->joinLeft('findspots', 'finds.secuid = findspots.findID',
+                )
+            )
+            ->joinLeft(
+                'findspots',
+                'finds.secuid = findspots.findID',
                 array(
                     'regionID',
                     'countyID',
@@ -2130,8 +2890,11 @@ class Finds extends Pas_Db_Table_Abstract
                     'precision' => 'gridlen',
                     'geohash',
                     'findspotcode' => 'old_findspotID'
-                ))
-            ->joinLeft('coins', 'finds.secuid = coins.findID',
+                )
+            )
+            ->joinLeft(
+                'coins',
+                'finds.secuid = coins.findID',
                 array(
                     'geographyID',
                     'ruler' => 'ruler_id',
@@ -2155,106 +2918,205 @@ class Finds extends Pas_Db_Table_Abstract
                     'axis' => 'die_axis_measurement',
                     'rrcID',
                     'ricID'
-                ))
-            ->joinLeft('mints', 'mints.id = coins.mint_ID',
+                )
+            )
+            ->joinLeft(
+                'mints',
+                'mints.id = coins.mint_ID',
                 array(
                     'mintName' => 'mint_name',
                     'pleiadesID',
                     'nomismaMintID' => 'nomismaID',
                     'mintWoeid' => 'woeid',
                     'mintBM' => 'bmID'
-                ))
-            ->joinLeft('denominations', 'coins.denomination = denominations.id',
+                )
+            )
+            ->joinLeft(
+                'denominations',
+                'coins.denomination = denominations.id',
                 array(
                     'denominationName' => 'denomination'
-                ))
-            ->joinLeft('rulers', 'coins.ruler_id = rulers.id',
+                )
+            )
+            ->joinLeft(
+                'rulers',
+                'coins.ruler_id = rulers.id',
                 array(
                     'rulerName' => 'issuer',
                     'rulerNomisma' => 'nomismaID',
                     'rulerDbpedia' => 'dbpedia',
                     'rulerBM' => 'bmID',
                     'rulerViaf' => 'viaf'
-                ))
-            ->joinLeft('users', 'users.id = finds.createdBy',
+                )
+            )
+            ->joinLeft(
+                'users',
+                'users.id = finds.createdBy',
                 array(
                     'creator' => new Zend_Db_Expr("CONCAT(users.first_name,' ',users.last_name)")
-                ))
-            ->joinLeft(array('users2' => 'users'), 'users2.id = finds.updatedBy',
-                array('updatedBy' => 'fullname'))
-            ->joinLeft(array('mat' => 'materials'), 'finds.material1 = mat.id',
+                )
+            )
+            ->joinLeft(
+                array('users2' => 'users'),
+                'users2.id = finds.updatedBy',
+                array('updatedBy' => 'fullname')
+            )
+            ->joinLeft(
+                array('mat' => 'materials'),
+                'finds.material1 = mat.id',
                 array(
                     'materialTerm' => 'term',
                     'primaryMaterialBM' => 'bmID'
-                ))
-            ->joinLeft(array('mat2' => 'materials'), 'finds.material2 = mat2.id',
+                )
+            )
+            ->joinLeft(
+                array('mat2' => 'materials'),
+                'finds.material2 = mat2.id',
                 array(
                     'secondaryMaterialTerm' => 'term',
                     'secondaryMaterialBM' => 'bmID'
-                ))
-            ->joinLeft('decstyles', 'finds.decstyle = decstyles.id',
-                array('decstyleTerm' => 'term'))
-            ->joinLeft('manufactures', 'finds.manmethod = manufactures.id',
-                array('manufactureTerm' => 'term'))
-            ->joinLeft('surftreatments', 'finds.surftreat = surftreatments.id',
-                array('treatment' => 'term'))
-            ->joinLeft('completeness', 'finds.completeness = completeness.id',
-                array('completenessTerm' => 'term'))
-            ->joinLeft('preservations', 'finds.preservation = preservations.id',
-                array('preservationTerm' => 'term'))
-            ->joinLeft('periods', 'finds.objdate1period = periods.id',
-                array('periodFromName' => 'term', 'periodFromBM' => 'bmID'))
-            ->joinLeft(array('sub1' => 'subperiods'),
+                )
+            )
+            ->joinLeft(
+                'decstyles',
+                'finds.decstyle = decstyles.id',
+                array('decstyleTerm' => 'term')
+            )
+            ->joinLeft(
+                'manufactures',
+                'finds.manmethod = manufactures.id',
+                array('manufactureTerm' => 'term')
+            )
+            ->joinLeft(
+                'surftreatments',
+                'finds.surftreat = surftreatments.id',
+                array('treatment' => 'term')
+            )
+            ->joinLeft(
+                'completeness',
+                'finds.completeness = completeness.id',
+                array('completenessTerm' => 'term')
+            )
+            ->joinLeft(
+                'preservations',
+                'finds.preservation = preservations.id',
+                array('preservationTerm' => 'term')
+            )
+            ->joinLeft(
+                'periods',
+                'finds.objdate1period = periods.id',
+                array('periodFromName' => 'term', 'periodFromBM' => 'bmID')
+            )
+            ->joinLeft(
+                array('sub1' => 'subperiods'),
                 'finds.objdate1subperiod = sub1.id',
-                array('subperiodFrom' => 'term'))
-            ->joinLeft(array('sub2' => 'subperiods'),
+                array('subperiodFrom' => 'term')
+            )
+            ->joinLeft(
+                array('sub2' => 'subperiods'),
                 'finds.objdate2subperiod = sub2.id',
-                array('subperiodTo' => 'term'))
-            ->joinLeft(array('p' => 'periods'), 'finds.objdate2period = p.id',
+                array('subperiodTo' => 'term')
+            )
+            ->joinLeft(
+                array('p' => 'periods'),
+                'finds.objdate2period = p.id',
                 array(
                     'periodToName' => 'term',
                     'periodToBM' => 'bmID'
-                ))
-            ->joinLeft(array('p2' => 'periods'), 'finds.broadperiod = p2.term',
-                array('broadperiodBM' => 'bmID'))
-            ->joinLeft('cultures', 'finds.culture = cultures.id',
-                array('cultureName' => 'term', 'bmCultureID'))
-            ->joinLeft('discmethods', 'discmethods.id = finds.discmethod',
-                array('discoveryMethod' => 'method'))
-            ->joinLeft('subsequentActions', 'finds.subs_action = subsequentActions.id',
-                array('subsequentActionTerm' => 'action'))
-            ->joinLeft('finds_images', 'finds.secuid = finds_images.find_id',
-                array())
-            ->joinLeft('slides', 'slides.secuid = finds_images.image_id',
-                array('filename', 'thumbnail' => 'imageID'))
-            ->joinLeft(array('users3' => 'users'), 'users3.id = slides.createdBy',
-                array('imagedir'))
-            ->joinLeft('rallies', 'finds.rallyID = rallies.id',
-                array('rallyName' => 'rally_name'))
-            ->joinLeft('ironagetribes', 'coins.tribe = ironagetribes.id',
-                array('tribeName' => 'tribe', 'bmTribeID'))
-            ->joinLeft('medievalcategories', 'medievalcategories.id = coins.categoryID',
-                array('categoryTerm' => 'category'))
-            ->joinLeft('medievaltypes', 'medievaltypes.id = coins.typeID',
-                array('typeTerm' => 'type'))
-            ->joinLeft('geographyironage', 'geographyironage.id = coins.geographyID',
-                array('geography' => new Zend_Db_Expr("CONCAT(geographyironage.region,',',area)")))
-            ->joinLeft('moneyers', 'coins.moneyer = moneyers.id',
-                array('moneyerName' => 'name', 'moneyerViaf' => 'viaf', 'moneyerBM' => 'bmID'))
-            ->joinLeft('osRegions', 'findspots.regionID = osRegions.osID',
-                array('regionName' => 'label'))
-            ->joinLeft('people', 'finds.finderID = people.secuid',
-                array('finder' => 'fullname'))
+                )
+            )
+            ->joinLeft(
+                array('p2' => 'periods'),
+                'finds.broadperiod = p2.term',
+                array('broadperiodBM' => 'bmID')
+            )
+            ->joinLeft(
+                'cultures',
+                'finds.culture = cultures.id',
+                array('cultureName' => 'term', 'bmCultureID')
+            )
+            ->joinLeft(
+                'discmethods',
+                'discmethods.id = finds.discmethod',
+                array('discoveryMethod' => 'method')
+            )
+            ->joinLeft(
+                'subsequentActions',
+                'finds.subs_action = subsequentActions.id',
+                array('subsequentActionTerm' => 'action')
+            )
+            ->joinLeft(
+                'finds_images',
+                'finds.secuid = finds_images.find_id',
+                array()
+            )
+            ->joinLeft(
+                'slides',
+                'slides.secuid = finds_images.image_id',
+                array('filename', 'thumbnail' => 'imageID')
+            )
+            ->joinLeft(
+                array('users3' => 'users'),
+                'users3.id = slides.createdBy',
+                array('imagedir')
+            )
+            ->joinLeft(
+                'rallies',
+                'finds.rallyID = rallies.id',
+                array('rallyName' => 'rally_name')
+            )
+            ->joinLeft(
+                'ironagetribes',
+                'coins.tribe = ironagetribes.id',
+                array('tribeName' => 'tribe', 'bmTribeID')
+            )
+            ->joinLeft(
+                'medievalcategories',
+                'medievalcategories.id = coins.categoryID',
+                array('categoryTerm' => 'category')
+            )
+            ->joinLeft(
+                'medievaltypes',
+                'medievaltypes.id = coins.typeID',
+                array('typeTerm' => 'type')
+            )
+            ->joinLeft(
+                'geographyironage',
+                'geographyironage.id = coins.geographyID',
+                array('geography' => new Zend_Db_Expr("CONCAT(geographyironage.region,',',area)"))
+            )
+            ->joinLeft(
+                'moneyers',
+                'coins.moneyer = moneyers.id',
+                array('moneyerName' => 'name', 'moneyerViaf' => 'viaf', 'moneyerBM' => 'bmID')
+            )
+            ->joinLeft(
+                'osRegions',
+                'findspots.regionID = osRegions.osID',
+                array('regionName' => 'label')
+            )
+            ->joinLeft(
+                'people',
+                'finds.finderID = people.secuid',
+                array('finder' => 'fullname')
+            )
             ->joinLeft('jettonClasses', 'coins.jettonClass = jettonClasses.id', array('jettonClass' => 'className'))
             ->joinLeft('jettonTypes', 'coins.jettonType = jettonTypes.id', array('jettonType' => 'typeName'))
             ->joinLeft('jettonGroup', 'coins.jettonGroup = jettonGroup.id', array('jettonGroup' => 'groupName'))
             ->joinLeft('sketchFab', 'finds.secuid = sketchFab.findID', array('3D' => 'modelID'))
-            ->joinLeft(array('recorder' => 'people'),
+            ->joinLeft(
+                array('recorder' => 'people'),
                 'finds.recorderID =recorder.secuid',
-                array('recorder' => 'fullname'))
-            ->joinLeft('certaintytypes', 'certaintytypes.id = finds.objecttypecert',
-                array('objectCertainty' => 'term',
-                      'objectCertaintyID' => 'id'))
+                array('recorder' => 'fullname')
+            )
+            ->joinLeft(
+                'certaintytypes',
+                'certaintytypes.id = finds.objecttypecert',
+                array(
+                    'objectCertainty' => 'term',
+                    'objectCertaintyID' => 'id'
+                )
+            )
             ->where('finds.id = ?', (int)$findID)
             ->group('finds.id')
             ->limit(1);
@@ -2263,6 +3125,7 @@ class Finds extends Pas_Db_Table_Abstract
     }
 
     /** Retrieve a user's count and quantity of finds recorded
+     *
      * @access public
      * @param integer $id
      * @return array
@@ -2270,9 +3133,13 @@ class Finds extends Pas_Db_Table_Abstract
     public function getCountFinds($id)
     {
         $select = $this->select()
-            ->from('finds', array(
-                'records' => 'COUNT(finds.id)',
-                'finds' => 'SUM(finds.quantity)'))
+            ->from(
+                'finds',
+                array(
+                    'records' => 'COUNT(finds.id)',
+                    'finds' => 'SUM(finds.quantity)'
+                )
+            )
             ->where('finds.createdBy = ?', (int)$id);
         return $this->getAdapter()->fetchAll($select);
     }


### PR DESCRIPTION
The region name was found to be missing on most records when exporting coins as a CSV.  This was found to be caused by a problem with the SQL query used by the SOLR indexing function.

This fix will apply to all new records, and records that are edited after this fix.  To force this change on a single record, press the 'Force index update' button on the records page. 