### PR TITLE
Update footer links to be HTTPs

### DIFF
--- a/app/views/scripts/structure/footer.phtml
+++ b/app/views/scripts/structure/footer.phtml
@@ -1,6 +1,6 @@
 <div class="row-fluid ">
     <div class="span3">
-        <a href="http://www.britishmuseum.org" title="The British Museum website">
+        <a href="https://www.britishmuseum.org" title="The British Museum website">
             <img class="sponsors" src="<?php echo $this->baseUrl(); ?>/assets/logos/bm_logo.png" width="150" height="60"
                  alt="The British Museum logo"/></a>
     </div>
@@ -49,14 +49,14 @@
     <div class="span3 ">
         <h4 class="lead">Join the conversation</h4>
         <ul>
-            <li><a href="http://www.twitter.com/#!/findsorguk" title="Our social media presence on Twitter">Twitter</a>
+            <li><a href="https://www.twitter.com/findsorguk" title="Our social media presence on Twitter">Twitter</a>
             </li>
-            <li><a href="http://facebook.com/portableantiquitiesscheme" title="Our social media presence on Facebook">Facebook</a>
+            <li><a href="https://facebook.com/portableantiquitiesscheme" title="Our social media presence on Facebook">Facebook</a>
             </li>
-            <li><a href="http://flickr.com/finds" title="Our social media presence on Flickr">Flickr</a></li>
-            <li><a href="http://www.youtube.com/user/portableantiquities" title="Our social media presence on Youtube">YouTube</a>
+            <li><a href="https://flickr.com/finds" title="Our social media presence on Flickr">Flickr</a></li>
+            <li><a href="https://www.youtube.com/user/portableantiquities" title="Our social media presence on Youtube">YouTube</a>
             </li>
-            <li><a href="http://pinterest.com/findsorguk/" title="Our social media presence on Pinterst">Pinterest</a>
+            <li><a href="https://pinterest.com/findsorguk/" title="Our social media presence on Pinterst">Pinterest</a>
             </li>
         </ul>
     </div>
@@ -66,7 +66,7 @@
 <div class="row-fluid ">
 
     <div class="span3">
-        <a href="http://www.culture.gov.uk" title="The Department of Culture, Media and Sport website"><img
+        <a href="https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport" title="The Department of Culture, Media and Sport website"><img
                 src="<?php echo $this->baseUrl(); ?>/assets/logos/dcms.png" width="80" height="70" alt="DCMS logo"
                 class="sponsors"/></a>
     </div>
@@ -104,7 +104,7 @@
         <div class="address">
             <strong>&copy; <?php echo $this->romanNumerals()->setDate(2003); ?>
                 - <?php echo $this->romanNumerals()->setDate(Zend_Date::now()->toString('yyyy')); ?></strong> &raquo; <a
-                rel="license" href="http://creativecommons.org/licenses/by/3.0/">CC-BY</a> <br/><span
+                rel="license" href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a> <br/><span
                 class="vcard"><span class="adr"><span class="org fn">The British Museum</span>, <span
                         class="street-address">Great Russell Street</span>, <span class="locality">London</span> <span
                         class="postal-code">WC1B 3DG</span>.</span><br /> T: <span class="tel"><span class="value">+44(0) 20 73238618</span></span>


### PR DESCRIPTION
Edits several of the links on the footer on the site to use the more secure HTTPS, rather than HTTP. 

Also changes URL for DCMS to its new home in the UK GOV website, preventing a redirect for users.
