### PR TITLE
Allow editing of numismatic data when third party data sources are offline

### DIFF
--- a/app/models/Nomisma.php
+++ b/app/models/Nomisma.php
@@ -74,13 +74,13 @@ class Nomisma
         $mail = new Zend_Mail();
         $adminEmails = Zend_Registry::get('config')->admin->email;
         $mail->setBodyHtml(
-            'The server has encountered an issue with Nomsima. The issue is as follows: </br></br>'
+            'The server has encountered an issue with Nomisma. The issue is as follows: </br></br>'
             . '<table>' . $error . '</table>'
         )
             ->setFrom('past@britishmuseum.org', 'The Portable Antiquities Scheme')
             ->addTo('past@britishmuseum.org', 'The Portable Antiquities Scheme')
             ->addTo($adminEmails ? $adminEmails->toArray() : null)
-            ->setSubject('PAS - Error retrieving ' . $type . ' from Nomsima')
+            ->setSubject('PAS - Error retrieving ' . $type . ' from Nomisma')
             ->send();
     }
 

--- a/app/models/Nomisma.php
+++ b/app/models/Nomisma.php
@@ -76,17 +76,20 @@ class Nomisma
             \EasyRdf\RdfNamespace::set('nmo', 'http://nomisma.org/ontology#');
             \EasyRdf\RdfNamespace::set('skos', 'http://www.w3.org/2004/02/skos/core#');
             \EasyRdf\RdfNamespace::set('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#');
-            $sparql = new Pas_RDF_EasyRdf_Client('http://nomisma.org/query');
-            $data = $sparql->query(
-                'SELECT * WHERE {' .
-                '  ?type ?role nm:' . $identifier . ' ;' .
-                '   a nmo:TypeSeriesItem ;' .
-                '  skos:prefLabel ?label' .
-                '  FILTER(langMatches(lang(?label), "en"))' .
-                '  OPTIONAL {?type nmo:hasStartDate ?startDate}' .
-                '  OPTIONAL {?type nmo:hasEndDate ?endDate}' .
-                ' } ORDER BY ?label');
-            $this->getCache()->save($data);
+            try {
+                $sparql = new Pas_RDF_EasyRdf_Client('http://nomisma.org/query');
+                $data = $sparql->query(
+                    'SELECT * WHERE {' .
+                    '  ?type ?role nm:' . $identifier . ' ;' .
+                    '   a nmo:TypeSeriesItem ;' .
+                    '  skos:prefLabel ?label' .
+                    '  FILTER(langMatches(lang(?label), "en"))' .
+                    '  OPTIONAL {?type nmo:hasStartDate ?startDate}' .
+                    '  OPTIONAL {?type nmo:hasEndDate ?endDate}' .
+                    ' } ORDER BY ?label');
+                $this->getCache()->save($data);
+            } catch (Exception $e) {
+            }
         } else {
             $data = $this->getCache()->load($key);
         }
@@ -125,23 +128,26 @@ class Nomisma
     {
         $key = md5($identifier . 'ricTypes');
         if (!($this->getCache()->test($key))) {
-
             //Add the namespaces needed to parse the query
             \EasyRdf\RdfNamespace::set('nm', 'http://nomisma.org/id/');
             \EasyRdf\RdfNamespace::set('nmo', 'http://nomisma.org/ontology#');
             \EasyRdf\RdfNamespace::set('skos', 'http://www.w3.org/2004/02/skos/core#');
             \EasyRdf\RdfNamespace::set('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#');
-            $sparql = new Pas_RDF_EasyRdf_Client('http://nomisma.org/query');
-            $data = $sparql->query(
-                'SELECT * WHERE {' .
-                '  ?type ?role nm:' . $identifier . ' ;' .
-                '   a nmo:TypeSeriesItem ;' .
-                '  skos:prefLabel ?label' .
+            try {
+                $sparql = new Pas_RDF_EasyRdf_Client('http://nomisma.org/query');
+                $data = $sparql->query(
+                    'SELECT * WHERE {' .
+                    '  ?type ?role nm:' . $identifier . ' ;' .
+                    '   a nmo:TypeSeriesItem ;' .
+                    '  skos:prefLabel ?label' .
 //                '  OPTIONAL {?type nmo:hasStartDate ?startDate}' .
 //                '  OPTIONAL {?type nmo:hasEndDate ?endDate}' .
-                '  FILTER(langMatches(lang(?label), "en"))' .
-                ' } ORDER BY ?label');
-            $this->getCache()->save($data);
+                    '  FILTER(langMatches(lang(?label), "en"))' .
+                    ' } ORDER BY ?label'
+                );
+                $this->getCache()->save($data);
+            } catch (Exception $e) {
+            }
         } else {
             $data = $this->getCache()->load($key);
         }

--- a/app/modules/default/controllers/AjaxController.php
+++ b/app/modules/default/controllers/AjaxController.php
@@ -560,12 +560,7 @@ class AjaxController extends Pas_Controller_Action_Ajax
             $rulers = new Rulers();
             $nomismaID = $rulers->fetchRow($rulers->select()->where('id = ?', $this->getParam('term')))->nomismaID;
             $nomisma = new Nomisma();
-            $types = null;
-
-            if (!empty($nomismaID)) {
-                $types = $nomisma->getRICDropdowns($nomismaID);
-            }
-
+            $types = $nomismaID ? $nomisma->getRICDropdowns($nomismaID) : null;
             if ($types) {
                 $response = $types;
             } else {

--- a/app/modules/default/controllers/AjaxController.php
+++ b/app/modules/default/controllers/AjaxController.php
@@ -536,14 +536,20 @@ class AjaxController extends Pas_Controller_Action_Ajax
         if ($this->getParam('term', false)) {
             $moneyer = new Moneyers();
             $nomismaID = $moneyer->fetchRow($moneyer->select()->where('id = ?', $this->getParam('term')))->nomismaID;
-            $nomisma = new Nomisma();
-            $types = $nomisma->getRRCDropdowns($nomismaID);
+//            $nomisma = new Nomisma();
+//            $types = $nomisma->getRRCDropdowns($nomismaID);
+//
+//            if ($types) {
+//                $response = $types;
+//            } else {
+//                $response = array(array('id' => null, 'term' => 'No options available'));
+//            }
 
-            if ($types) {
-                $response = $types;
-            } else {
+            $response = $nomismaID ? (new Nomisma())->getRRCDropdowns($nomismaID) : null;
+            if (empty($response)) {
                 $response = array(array('id' => null, 'term' => 'No options available'));
             }
+
         } else {
             $response = array(array('id' => null, 'term' => 'No moneyer specified'));
         }
@@ -559,8 +565,10 @@ class AjaxController extends Pas_Controller_Action_Ajax
         if ($this->getParam('term', false)) {
             $rulers = new Rulers();
             $nomismaID = ($rulers)->fetchRow($rulers->select()->where('id = ?', $this->getParam('term')))->nomismaID;
-            $response = !empty($nomismaID) ? (new Nomisma())->getRICDropdowns($nomismaID) :
-                array(array('id' => null, 'term' => 'No options available'));
+            $response = $nomismaID ? (new Nomisma())->getRICDropdowns($nomismaID) : null;
+            if (empty($response)) {
+                $response = array(array('id' => null, 'term' => 'No options available'));
+            }
         } else {
             $response = array(array('id' => null, 'term' => 'No ruler specified'));
         }

--- a/app/modules/default/controllers/AjaxController.php
+++ b/app/modules/default/controllers/AjaxController.php
@@ -558,14 +558,9 @@ class AjaxController extends Pas_Controller_Action_Ajax
     {
         if ($this->getParam('term', false)) {
             $rulers = new Rulers();
-            $nomismaID = $rulers->fetchRow($rulers->select()->where('id = ?', $this->getParam('term')))->nomismaID;
-            $nomisma = new Nomisma();
-            $types = $nomismaID ? $nomisma->getRICDropdowns($nomismaID) : null;
-            if ($types) {
-                $response = $types;
-            } else {
-                $response = array(array('id' => null, 'term' => 'No options available'));
-            }
+            $nomismaID = ($rulers)->fetchRow($rulers->select()->where('id = ?', $this->getParam('term')))->nomismaID;
+            $response = !empty($nomismaID) ? (new Nomisma())->getRICDropdowns($nomismaID) :
+                array(array('id' => null, 'term' => 'No options available'));
         } else {
             $response = array(array('id' => null, 'term' => 'No ruler specified'));
         }

--- a/app/modules/default/controllers/AjaxController.php
+++ b/app/modules/default/controllers/AjaxController.php
@@ -560,7 +560,12 @@ class AjaxController extends Pas_Controller_Action_Ajax
             $rulers = new Rulers();
             $nomismaID = $rulers->fetchRow($rulers->select()->where('id = ?', $this->getParam('term')))->nomismaID;
             $nomisma = new Nomisma();
-            $types = $nomisma->getRICDropdowns($nomismaID);
+            $types = null;
+
+            if (!empty($nomismaID)) {
+                $types = $nomisma->getRICDropdowns($nomismaID);
+            }
+
             if ($types) {
                 $response = $types;
             } else {

--- a/library/Pas/Controller/Action/Helper/CoinFormLoader.php
+++ b/library/Pas/Controller/Action/Helper/CoinFormLoader.php
@@ -133,7 +133,7 @@ class Pas_Controller_Action_Helper_CoinFormLoader extends Zend_Controller_Action
             default:
                 throw new Exception('You cannot have a coin for that period.');
         }
-        $this->initNomsimaDropdowns($form);
+        $this->initNomismaDropdowns($form);
         return $form;
     }
 
@@ -152,7 +152,7 @@ class Pas_Controller_Action_Helper_CoinFormLoader extends Zend_Controller_Action
             ));
     }
 
-    private function initNomsimaDropdowns($form)
+    private function initNomismaDropdowns($form)
     {
         $rrcTypes = new Nomisma();
         $errorMessageNomisma = 'Nomisma - the third party data source - is ' .

--- a/library/Pas/Controller/Action/Helper/CoinFormLoader.php
+++ b/library/Pas/Controller/Action/Helper/CoinFormLoader.php
@@ -133,7 +133,35 @@ class Pas_Controller_Action_Helper_CoinFormLoader extends Zend_Controller_Action
             default:
                 throw new Exception('You cannot have a coin for that period.');
         }
+        $this->initNomsimaDropdowns($form);
         return $form;
+    }
+
+    private function setFormDisabled($element, $errorMessage){
+        $element->setDescription($errorMessage)
+            ->setAttrib('tabindex', '-1')
+            ->setAttrib('style', 'pointer-events:none; background: #eee;')
+            ->addDecorators(array(
+                array(
+                    'Description',
+                    array(
+                        'tag' => 'p',
+                        'style' => 'color:#e95420; font-weight: bold; margin-top:5px;'
+                    )
+                ),
+            ));
+    }
+
+    private function initNomsimaDropdowns($form)
+    {
+        $rrcTypes = new Nomisma();
+        $errorMessageNomisma = 'Nomisma - the third party data source - is ' .
+            'currently unavailable. Please try again later';
+
+        if ($rrcTypes->getStatusNomisma() == false) {
+            $this->setFormDisabled($form->rrcID, $errorMessageNomisma);
+            $this->setFormDisabled($form->ricID, $errorMessageNomisma);
+        }
     }
 
     /** Clone the options

--- a/library/Pas/Controller/Action/Helper/CoinFormLoaderOptions.php
+++ b/library/Pas/Controller/Action/Helper/CoinFormLoaderOptions.php
@@ -146,7 +146,7 @@ class Pas_Controller_Action_Helper_CoinFormLoaderOptions extends Zend_Controller
                     if (!is_null($coinDataFlat['ruler_id'])) {
                         $rulers = new Rulers();
                         $identifier = $rulers->fetchRow($rulers->select()->where('id = ?', $coinDataFlat['ruler_id']));
-                        if ($identifier) {
+                        if ($identifier && $identifier->nomismaID) {
                             $this->addDropdown(
                                 $this->_view->form->ricID,
                                 (new Nomisma())->getRICDropdownsFlat($identifier->nomismaID),

--- a/library/Pas/Controller/Action/Helper/CoinFormLoaderOptions.php
+++ b/library/Pas/Controller/Action/Helper/CoinFormLoaderOptions.php
@@ -104,7 +104,7 @@ class Pas_Controller_Action_Helper_CoinFormLoaderOptions extends Zend_Controller
         Zend_Form_Element_Select $formElement,
         array $dropdownValues,
         string $type,
-        string $coinId
+        ?string $coinId
     ) {
         if ($dropdownValues || $coinId) {
             $formElement->addMultiOptions(

--- a/library/Pas/Controller/Action/Helper/CoinFormLoaderOptions.php
+++ b/library/Pas/Controller/Action/Helper/CoinFormLoaderOptions.php
@@ -77,7 +77,8 @@ class Pas_Controller_Action_Helper_CoinFormLoaderOptions extends Zend_Controller
         return $this->optionsAddClone($broadperiod, $coinDataFlat);
     }
 
-    /** add and clone last record
+    /** Add and clone last record
+     * fill options when coin has data
      * @access public
      * @param string $broadperiod
      * @param array $coinDataFlat
@@ -108,10 +109,24 @@ class Pas_Controller_Action_Helper_CoinFormLoaderOptions extends Zend_Controller
                         if ($identifier) {
                             $nomisma = $identifier->nomismaID;
                             $rrcTypes = new Nomisma();
-                            $this->_view->form->ricID->addMultiOptions(array(
-                                null => 'Choose RIC type',
-                                'Available RIC types' => $rrcTypes->getRICDropdownsFlat($nomisma)
-                            ));
+                            $ricDropdowns = $rrcTypes->getRICDropdownsFlat($nomisma);
+
+                            if (!empty($ricDropdowns)) {
+                                $this->_view->form->ricID->addMultiOptions(array(
+                                    null => 'Choose RIC type',
+                                    'Available RIC types' => $ricDropdowns
+                                ));
+                            } elseif (!empty($coinDataFlat['ricID'])) {
+                                $this->_view->form->ricID->addMultiOptions(array(
+                                    null => 'Choose RIC type',
+                                    'Available RIC types' => array(
+                                        $coinDataFlat['ricID'] =>
+                                            strtoupper(
+                                                str_replace('-', ' ', str_replace('.', '/', $coinDataFlat['ricID']))
+                                            )
+                                    )
+                                ));
+                            }
                         }
                     }
 
@@ -147,10 +162,24 @@ class Pas_Controller_Action_Helper_CoinFormLoaderOptions extends Zend_Controller
                             if ($identifier) {
                                 $nomisma = $identifier->nomismaID;
                                 $rrcTypes = new Nomisma();
-                                $this->_view->form->rrcID->addMultiOptions(array(
-                                    null => 'Choose RRC type',
-                                    'Available RRC types' => $rrcTypes->getRRCDropdownsFlat($nomisma)
-                                ));
+                                $rrcDropdowns = $rrcTypes->getRRCDropdownsFlat($nomisma);
+
+                                if (!empty($rrcDropdowns)) {
+                                    $this->_view->form->rrcID->addMultiOptions(array(
+                                        null => 'Choose RRC type',
+                                        'Available RRC types' => $rrcDropdowns
+                                    ));
+                                } elseif (!empty($coinDataFlat['rrcID'])) {
+                                    $this->_view->form->rrcID->addMultiOptions(array(
+                                        null => 'Choose RRC type',
+                                        'Available RRC types' => array(
+                                            $coinDataFlat['rrcID'] =>
+                                                strtoupper(
+                                                    str_replace('-', ' ', str_replace('.', '/', $coinDataFlat['rrcID']))
+                                                )
+                                        )
+                                    ));
+                                }
                             }
                         }
                     }

--- a/library/Pas/Validate/Imperial.php
+++ b/library/Pas/Validate/Imperial.php
@@ -12,47 +12,25 @@
  * @use Pas_Curl
  * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
  */
-class Pas_Validate_Imperial extends Zend_Validate_Abstract
+class Pas_Validate_Imperial extends Pas_Validate_NumismaticsAbstract
 {
-
-    /** The not valid message container
-     *
+    /** The error message
+     * @access protected
+     * @var string
      */
-    const NOT_VALID = 'notValid';
+    protected $_url = 'http://numismatics.org/ocre/id/';
 
     /** Validation failure message template definitions
      * @access protected
      * @var array
      */
-    protected $_messageTemplates = array(self::NOT_VALID => 'That is not a valid RIC ID.',);
+    protected $_messageTemplates = array(self::NOT_VALID => 'That is not a valid RIC ID.',
+        self::HTTP_ERROR => 'Numismatics - the third party data source - is currently unavailable.' .
+            ' Please try again later.');
 
-    /** Check if the value is valid
-     * @access @access public
-     * @param string $value
-     * @return boolean
+    /** The error message email subject
+     * @access protected
+     * @var string
      */
-    public function isValid($value)
-    {
-        $type = $this->getType($value);
-        if (!$type) {
-            $this->_error(self::NOT_VALID);
-            return false;
-        }
-        return true;
-    }
-
-    /** Get whether the rrcID exists in the CORR system
-     * @access public
-     * @param string $value
-     * @return string
-     */
-    public function getType($rrcID)
-    {
-        $curl = new Pas_Curl();
-        $curl->setUri('http://numismatics.org/ocre/id/' . $rrcID);
-        $curl->getRequest();
-        if($curl->getResponseCode() == '200') {
-            return true;
-        }
-    }
+    protected $_errorMessageSubject = 'PAS - Error validating ricID from Numismatics';
 }

--- a/library/Pas/Validate/NumismaticsAbstract.php
+++ b/library/Pas/Validate/NumismaticsAbstract.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * A validation class for checking for whether a RRC id provided is valid
+ *
+ * @author Daniel Pett <dpett@britishmuseum.org>
+ * @copyright (c) 2014 Daniel Pett
+ * @category Pas
+ * @package Pas_Validate
+ * @version 1
+ * @see Zend_Validate_Abstract
+ * @use Pas_Curl
+ * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
+ */
+abstract class Pas_Validate_NumismaticsAbstract extends Zend_Validate_Abstract
+{
+
+    /** The not valid message container
+     *
+     */
+    protected const NOT_VALID = 'notValid';
+
+    /** The http error message container
+     *
+     */
+    protected const HTTP_ERROR = 'httpError';
+
+    /** Validation failure message template definitions
+     * @access protected
+     * @var array
+     */
+    protected $_messageTemplates;
+
+    /** The error message
+     * @access protected
+     * @var string
+     */
+    protected $_errorMessage;
+
+    /** The error message email subject
+     * @access protected
+     * @var string
+     */
+    protected $_errorMessageSubject;
+
+    /** The error message
+     * @access protected
+     * @var string
+     */
+    protected $_url;
+
+    /** Check if the value is valid
+     * @access @access public
+     * @param string $value
+     * @return boolean
+     */
+    public function isValid($value)
+    {
+        $type = $this->getType($value);
+        if (!$type) {
+            $this->_error($this->_errorMessage);
+            return false;
+        }
+        return true;
+    }
+
+    /**Send Numismatics error email
+     * @param $error
+     * @param string $type
+     * @return void
+     * @throws Zend_Mail_Exception|Zend_Exception
+     */
+    public function sendErrorEmail($error)
+    {
+        $mail = new Zend_Mail();
+        $adminEmails = Zend_Registry::get('config')->admin->email;
+        $mail->setBodyHtml(
+            'The server has encountered an issue with the Numismatics site. The issue is as follows: </br></br>'
+            . $error
+        )
+            ->setFrom('past@britishmuseum.org', 'The Portable Antiquities Scheme')
+            ->addTo('past@britishmuseum.org', 'The Portable Antiquities Scheme')
+            ->addTo($adminEmails ? $adminEmails->toArray() : null)
+            ->setSubject($this->_errorMessageSubject)
+            ->send();
+    }
+
+    /** Get whether the ID exists in the CORR system
+     * @access public
+     * @param string $value
+     * @return string
+     */
+    public function getType($id)
+    {
+        $key = md5($id . get_class($this));
+        $cache = Zend_Registry::get('cache');
+
+        if (($cache->load($key)) !== false) {
+            return true;
+        } else {
+            // cache missed
+            $curl = new Pas_Curl();
+            $curl->setUri($this->_url . $id);
+
+            try {
+                $curl->getRequest();
+            } catch (Exception $e) {
+                $this->_errorMessage = self::HTTP_ERROR;
+                $this->sendErrorEmail($e);
+                return false;
+            }
+
+            $response = $curl->getResponseCode();
+            if ($curl->getResponseCode() == '200') {
+                $cache->save($response);
+                return true;
+            } elseif (preg_match('/5[0-9][0-9]/', $response)) {
+                $this->_errorMessage = self::HTTP_ERROR;
+            } else {
+                $this->_errorMessage = self::NOT_VALID;
+            }
+
+            $this->sendErrorEmail($response);
+            return false;
+        }
+    }
+}

--- a/library/Pas/Validate/Republican.php
+++ b/library/Pas/Validate/Republican.php
@@ -12,47 +12,26 @@
  * @use Pas_Curl
  * @license http://www.gnu.org/licenses/agpl-3.0.txt GNU Affero GPL v3.0
  */
-class Pas_Validate_Republican extends Zend_Validate_Abstract
+class Pas_Validate_Republican extends Pas_Validate_NumismaticsAbstract
 {
 
-    /** The not valid message container
-     *
+    /** The error message
+     * @access protected
+     * @var string
      */
-    const NOT_VALID = 'notValid';
+     protected $_url = 'http://numismatics.org/crro/id/';
 
     /** Validation failure message template definitions
      * @access protected
      * @var array
      */
-    protected $_messageTemplates = array(self::NOT_VALID => 'That is not a valid RRC ID.',);
+    protected $_messageTemplates = array(self::NOT_VALID => 'That is not a valid RRC ID.',
+        self::HTTP_ERROR => 'Numismatics - the third party data source - is currently unavailable.' .
+            ' Please try again later.');
 
-    /** Check if the value is valid
-     * @access @access public
-     * @param string $value
-     * @return boolean
+    /** The error message email subject
+     * @access protected
+     * @var string
      */
-    public function isValid($value)
-    {
-        $type = $this->getType($value);
-        if (!$type) {
-            $this->_error(self::NOT_VALID);
-            return false;
-        }
-        return true;
-    }
-
-    /** Get whether the rrcID exists in the CORR system
-     * @access public
-     * @param string $value
-     * @return string
-     */
-    public function getType($rrcID)
-    {
-        $curl = new Pas_Curl();
-        $curl->setUri('http://numismatics.org/crro/id/' . $rrcID);
-        $curl->getRequest();
-        if($curl->getResponseCode() == '200') {
-            return true;
-        }
-    }
+    protected $_errorMessageSubject = 'PAS - Error validating rrcID from Numismatics';
 }


### PR DESCRIPTION
When the third-party data source Nomisma fails, users attempting to edit numismatic data on Roman coins are directed to an error page.

This fix will now allow users to edit and save changes to numismatic data even when third-party sources are offline.  

In addition, new email notifications have been added to alert admins when Nomisma is down .
