### PR TITLE
feat: add press info to contact us page

### DIFF
--- a/app/modules/about/views/scripts/contactus/index.phtml
+++ b/app/modules/about/views/scripts/contactus/index.phtml
@@ -48,6 +48,7 @@ echo $this->form; ?>
     </li>
 </ul>
 <p>If you are enquiring about tickets please contact our box office.</p>
+<p>For all media enquiries email <a href="mailto:communications@britishmuseum.org">communications@britishmuseum.org</a>.</p>
 <p>If you are making a Freedom of Information request, please contact us directly via <a class="email" href="mailto:compliance@britishmuseum.org">compliance@britishmuseum.org</a>.
 </p>
  


### PR DESCRIPTION
Add the following text to the contact us section on the site: “For all media enquiries email communications@britishmuseum.org”