### PR TITLE
Fix: Homepage embed changes

### DIFF
--- a/app/config/webservices.ini.template
+++ b/app/config/webservices.ini.template
@@ -81,3 +81,15 @@ webservice.what3words.apikey =
 
 webservice.sketchfab.baseurl = 
 webservice.sketchfab.oembed =
+
+webservice.cookiebot.src =
+webservice.cookiebot.data-cbid =
+webservice.cookiebot.data-blockingmode =
+
+webservice.youtube.homepage.src =
+webservice.youtube.homepage.srcAlt =
+webservice.youtube.homepage.titleAttr =
+webservice.youtube.homepage.title =
+
+webservice.twitter.homepage.src =
+webservice.twitter.homepage.jsSrc =

--- a/app/modules/default/views/scripts/index/index.phtml
+++ b/app/modules/default/views/scripts/index/index.phtml
@@ -1,5 +1,6 @@
 <?php
 
+
 $this->headMeta('noodp', 'robots');
 $this->headMeta('BJ0IxlmtPbri25v9zbMgcOFDOBuZmNacd9-friMs1_E', 'google-site-verification');
 $this->jQuery()->addJavascriptFile('js/bootstrap-carousel.js', $type = 'text/javascript');
@@ -60,32 +61,14 @@ $this->headMeta($this->serverUrl() . '/assets/logos/axe.jpg', 'twitter:image');
 ==================================================
 Wrap the rest of the page in another container to center all the content. */ ?>
     <div class="container marketing">
-        
-    <br>
+
+        <br>
         <?php
         // Three columns of text below the carousel ?>
         <div class="row">
             <div class="span4">
 
-                <div class="embed-container">
-                    <iframe data-src="https://www.youtube.com/embed/bR4qwpN3TMw"
-                            data-cookieconsent="marketing"
-                            title="(Video) Code of Practice for Responsible Metal Detecting in England and Wales"
-                            frameborder="0"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                            allowfullscreen></iframe>
-                    <div class="cookieconsent-optout-marketing cookie-placeholder dark">
-                        <div style="color:white; font-family: Arial, sans-serif;">
-                            Please <a href="javascript:Cookiebot.renew()"
-                                      style="color:white !important; text-decoration:underline;">accept
-                                marketing-cookies</a> to watch this video
-                        </div>
-                    </div>
-                </div>
-                <br>
-                <h2 class="lead">Code of Practice</h2>
-                <a href="https://youtu.be/WO3vnD3c7ac" target="_blank">Video without subtitles</a>
-
+                <?= $this->render('structure/cookiebotYouTubeEmbed.phtml'); ?>
             </div>
             <div class="span4">
                 <img class="img" src="/assets/logos/pas.jpg" width="213" height="104">
@@ -94,38 +77,12 @@ Wrap the rest of the page in another container to center all the content. */ ?>
             <?php
             echo $this->form; ?>
         </div>
-
-        <div class="span4">
-            <?php
-            /*         <!--img class="img-circle" src="assets/logos/bird.jpg"-->
-                       <!--h2 class="lead">Latest tweets</h2--> */
-
-            ?>
-                <div class="embed-container" style="--aspect-ratio:16/13">
-                    <div class="cookieconsent-optin-marketing cookie-placeholder cookie-placeholder--reload">
-                        If you can see this, please <a href="#" onclick="window.location.reload(true)">refresh</a> your
-                        page
-                        to view these Tweets.
-                    </div>
-                    <div class="cookieconsent-optin-marketing">
-                        <a class="twitter-timeline" data-height="300"
-                           href="https://twitter.com/findsorguk?ref_src=twsrc%5Etfw">Tweets
-                            by findsorguk</a>
-                        <script async type="text/plain" data-cookieconsent="marketing"
-                                src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </div>
-                    <div class="cookieconsent-optout-marketing cookie-placeholder dark">
-                        <div style="color:white; font-family: Arial, sans-serif;">
-                            Please <a href="javascript:Cookiebot.renew()"
-                                      style="color:white !important; text-decoration:underline;">accept
-                                marketing-cookies</a> to view these tweets
-                        </div>
-                    </div>
-                </div>
-
+            <div class="span4">
+                <?php
+                echo $this->render('structure/cookiebotTwitterEmbed.phtml')
+                ?>
+            </div>
         </div>
-
-    </div>
 
     <hr class="featurette-divider">
 

--- a/app/views/scripts/structure/cookiebotTwitterEmbed.phtml
+++ b/app/views/scripts/structure/cookiebotTwitterEmbed.phtml
@@ -1,0 +1,27 @@
+<div class="embed-container" style="--aspect-ratio:16/13">
+    <div class="cookieconsent-optin-marketing cookie-placeholder cookie-placeholder--reload">
+        if you can see this, please
+        <a href="#" onclick="window.location.reload(true)">refresh</a>
+        your page to view these Tweets.
+    </div>
+
+    <div class="cookieconsent-optin-marketing">
+        <a class="twitter-timeline" data-height="300"
+           href="https://twitter.com/findsorguk?ref_src=twsrc%5Etfw">Tweets
+            by findsorguk</a>
+        <script async type="text/plain" data-cookieconsent="marketing"
+                src="https://platform.twitter.com/widgets.js"
+                charset="utf-8"></script>
+    </div>
+
+    <div class="cookieconsent-optout-marketing cookie-placeholder dark">
+        <div>
+            Please <a href="javascript:Cookiebot.renew()"
+                      style="color:white !important; text-decoration:underline;">accept
+                marketing-cookies</a> to view these tweets
+        </div>
+    </div>
+</div>
+
+
+

--- a/app/views/scripts/structure/cookiebotTwitterEmbed.phtml
+++ b/app/views/scripts/structure/cookiebotTwitterEmbed.phtml
@@ -1,16 +1,22 @@
+<?php
+$config = Zend_Registry::get('config')->webservice->twitter->homepage;
+empty($config) ?: $config = $config->toArray();
+?>
+
+<?php if (!empty($config['url']) && !empty($config['js-src'])) : ?>
+
 <div class="embed-container" style="--aspect-ratio:16/13">
     <div class="cookieconsent-optin-marketing cookie-placeholder cookie-placeholder--reload">
-        if you can see this, please
-        <a href="#" onclick="window.location.reload(true)">refresh</a>
-        your page to view these Tweets.
+        If you can see this, please <a href="#" onclick="window.location.reload(true)">refresh</a>
+        your <br>page to view these Tweets.
     </div>
 
     <div class="cookieconsent-optin-marketing">
         <a class="twitter-timeline" data-height="300"
-           href="https://twitter.com/findsorguk?ref_src=twsrc%5Etfw">Tweets
+           href="<?= $config['url'] ?>">Tweets
             by findsorguk</a>
         <script async type="text/plain" data-cookieconsent="marketing"
-                src="https://platform.twitter.com/widgets.js"
+                src="<?= $config['js-src'] ?>"
                 charset="utf-8"></script>
     </div>
 
@@ -23,5 +29,6 @@
     </div>
 </div>
 
+<?php endif;?>
 
 

--- a/app/views/scripts/structure/cookiebotTwitterEmbed.phtml
+++ b/app/views/scripts/structure/cookiebotTwitterEmbed.phtml
@@ -1,9 +1,8 @@
 <?php
-$config = Zend_Registry::get('config')->webservice->twitter->homepage;
-empty($config) ?: $config = $config->toArray();
+$twitterConfig = Zend_Registry::get('config')->webservice->twitter->homepage;
 ?>
 
-<?php if (!empty($config['url']) && !empty($config['js-src'])) : ?>
+<?php if (!empty($twitterConfig->src) && !empty($twitterConfig->jsSrc)) : ?>
 
 <div class="embed-container" style="--aspect-ratio:16/13">
     <div class="cookieconsent-optin-marketing cookie-placeholder cookie-placeholder--reload">
@@ -13,10 +12,10 @@ empty($config) ?: $config = $config->toArray();
 
     <div class="cookieconsent-optin-marketing">
         <a class="twitter-timeline" data-height="300"
-           href="<?= $config['url'] ?>">Tweets
+           href="<?= $twitterConfig->src ?>">Tweets
             by findsorguk</a>
         <script async type="text/plain" data-cookieconsent="marketing"
-                src="<?= $config['js-src'] ?>"
+                src="<?= $twitterConfig->jsSrc ?>"
                 charset="utf-8"></script>
     </div>
 

--- a/app/views/scripts/structure/cookiebotYouTubeEmbed.phtml
+++ b/app/views/scripts/structure/cookiebotYouTubeEmbed.phtml
@@ -1,0 +1,26 @@
+<?php
+
+$config = Zend_Registry::get('config')->webservice->youtube->homepage;
+
+empty($config) ?: $config = $config->toArray();
+
+?>
+
+<div class="embed-container">
+    <iframe data-src="<?= $config['src']; ?>"
+            data-cookieconsent="marketing"
+            title="<?= $config['title-attr']; ?>"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen></iframe>
+    <div class="cookieconsent-optout-marketing cookie-placeholder dark">
+        <div style="color:white; font-family: Arial, sans-serif;">
+            Please <a href="javascript:Cookiebot.renew()"
+                      style="color:white !important; text-decoration:underline;">accept
+                marketing-cookies</a> to watch this video
+        </div>
+    </div>
+</div>
+<br>
+<h2 class="lead"><?= $config['title']; ?></h2>
+<a href="<?= $config['src-alt']; ?>" target="_blank">Video without subtitles</a>

--- a/app/views/scripts/structure/cookiebotYouTubeEmbed.phtml
+++ b/app/views/scripts/structure/cookiebotYouTubeEmbed.phtml
@@ -6,6 +6,7 @@ empty($config) ?: $config = $config->toArray();
 
 ?>
 
+<?php if (!empty($config['src'])) : ?>
 <div class="embed-container">
     <iframe data-src="<?= $config['src']; ?>"
             data-cookieconsent="marketing"
@@ -21,6 +22,11 @@ empty($config) ?: $config = $config->toArray();
         </div>
     </div>
 </div>
+<?php endif;?>
 <br>
-<h2 class="lead"><?= $config['title']; ?></h2>
-<a href="<?= $config['src-alt']; ?>" target="_blank">Video without subtitles</a>
+
+
+<?php if (!empty($config['src-alt']) && !empty($config['title'])) : ?>
+    <h2 class="lead"><?= $config['title']; ?></h2>
+    <a href="<?= $config['src-alt']; ?>" target="_blank">Video without subtitles</a>
+<?php endif;?>

--- a/app/views/scripts/structure/cookiebotYouTubeEmbed.phtml
+++ b/app/views/scripts/structure/cookiebotYouTubeEmbed.phtml
@@ -1,16 +1,12 @@
 <?php
-
-$config = Zend_Registry::get('config')->webservice->youtube->homepage;
-
-empty($config) ?: $config = $config->toArray();
-
+$youtubeConfig = Zend_Registry::get('config')->webservice->youtube->homepage;
 ?>
 
-<?php if (!empty($config['src'])) : ?>
+<?php if (!empty($youtubeConfig->src)) : ?>
 <div class="embed-container">
-    <iframe data-src="<?= $config['src']; ?>"
+    <iframe data-src="<?= $youtubeConfig->src; ?>"
             data-cookieconsent="marketing"
-            title="<?= $config['title-attr']; ?>"
+            title="<?= $youtubeConfig->titleAttr ?? 'YouTube video player'; ?>"
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowfullscreen></iframe>
@@ -25,8 +21,7 @@ empty($config) ?: $config = $config->toArray();
 <?php endif;?>
 <br>
 
-
-<?php if (!empty($config['src-alt']) && !empty($config['title'])) : ?>
-    <h2 class="lead"><?= $config['title']; ?></h2>
-    <a href="<?= $config['src-alt']; ?>" target="_blank">Video without subtitles</a>
+<?php if (!empty($youtubeConfig->srcAlt) && !empty($youtubeConfig->title)) : ?>
+    <h2 class="lead"><?= $youtubeConfig->title; ?></h2>
+    <a href="<?= $youtubeConfig->src_alt; ?>" target="_blank">Video without subtitles</a>
 <?php endif;?>

--- a/public_html/css/custom.css
+++ b/public_html/css/custom.css
@@ -81,7 +81,7 @@
     transform: translate(-50%, -50%);
     -webkit-transform: translate(-50%, -50%);
     -ms-transform: translate(-50%, -50%);
-    width: 90%;
+    width: 100%;
     text-align: center;
 }
 

--- a/public_html/css/custom.css
+++ b/public_html/css/custom.css
@@ -82,6 +82,7 @@
     -webkit-transform: translate(-50%, -50%);
     -ms-transform: translate(-50%, -50%);
     width: 100%;
+    height: 100%;
     text-align: center;
 }
 

--- a/public_html/css/custom.css
+++ b/public_html/css/custom.css
@@ -52,8 +52,11 @@
 
 .cookie-show {
     visibility: visible !important;
-    -webkit-animation: fadeIn ease-in 1s;
-    animation: fadeIn ease-in 1s;
+    opacity:0;
+    animation: fadeIn 2s forwards;
+    -webkit-animation: fadeIn 2s forwards;
+    animation-delay: 5s;
+    -webkit-animation-delay: 5s;
 }
 
 .embed-container {


### PR DESCRIPTION
Due to changes in the Twitter embed on the homepage, the placeholder text shown if the element does not load, is overflowing behind the element. This change updated the CSS to resolve this, as well as: 

- Moving the YouTube and Twitter homepage embeds to their own partial file 
- Moving values such as URLs to a config to make changing them later, easier, and without the need for a code release
- Hide embeds if the values are null, rather than show broken elements