### PR TITLE
feat: numismatic data case

### DIFF
--- a/app/views/scripts/partials/database/numismatics/byzantineData.phtml
+++ b/app/views/scripts/partials/database/numismatics/byzantineData.phtml
@@ -45,16 +45,16 @@
                 title="view all records assigned to <?php echo $this->mintName; ?>"><i class="icon-search"></i></a><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseDescription)): ?>
-        Obverse description: <?php echo ucfirst($this->obverseDescription); ?><br/>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseInscription)): ?>
-        Obverse inscription: <?php echo $this->obverseInscription; ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseDescription)): ?>
-        Reverse description: <?php echo ucfirst($this->reverseDescription); ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseInscription)): ?>
-        Reverse inscription: <?php echo $this->reverseInscription; ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->dieAxisName)): ?>
         Die axis measurement: <?php echo $this->escape($this->dieAxisName); ?><br/>

--- a/app/views/scripts/partials/database/numismatics/earlymedievalData.phtml
+++ b/app/views/scripts/partials/database/numismatics/earlymedievalData.phtml
@@ -88,20 +88,20 @@
 
     <?php if (!is_null($this->obverseDescription)) : ?>
         <br />
-        Obverse description: <?php echo ucfirst($this->obverseDescription); ?>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?>
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseInscription)) : ?>
         <br />
-        Obverse inscription: <?php echo $this->obverseInscription; ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseDescription)) : ?>
-        Reverse description: <?php echo $this->reverseDescription; ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseInscription)) : ?>
-        Reverse inscription: <?php echo $this->reverseInscription; ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseMintmark)) : ?>

--- a/app/views/scripts/partials/database/numismatics/greekandromanprovincialData.phtml
+++ b/app/views/scripts/partials/database/numismatics/greekandromanprovincialData.phtml
@@ -45,16 +45,16 @@
                 title="view all records assigned to <?php echo $this->mintName; ?>"><i class="icon-search"></i></a><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseDescription)): ?>
-        Obverse description: <?php echo ucfirst($this->obverseDescription); ?><br/>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseInscription)): ?>
-        Obverse inscription: <?php echo $this->obverseInscription; ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseDescription)): ?>
-        Reverse description: <?php echo ucfirst($this->reverseDescription); ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseInscription)): ?>
-        Reverse inscription: <?php echo $this->reverseInscription; ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->dieAxisName)): ?>
         Die axis measurement: <?php echo $this->dieAxisName; ?><br/>

--- a/app/views/scripts/partials/database/numismatics/ironageData.phtml
+++ b/app/views/scripts/partials/database/numismatics/ironageData.phtml
@@ -102,22 +102,22 @@
 
     <?php if (!is_null($this->obverseDescription)) : ?>
         <br />
-        Obverse description: <?php echo $this->obverseDescription; ?>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?>
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseInscription)) : ?>
         <br />
-        Obverse inscription: <?php echo $this->obverseInscription; ?>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseDescription)) : ?>
         <br />
-        Reverse description: <?php echo $this->reverseDescription; ?>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseInscription)) : ?>
         <br />
-        Reverse inscription: <?php echo $this->reverseInscription; ?>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?>
     <?php endif; ?>
 
     <?php if (!is_null($this->dieAxisName)) : ?>

--- a/app/views/scripts/partials/database/numismatics/jettonData.phtml
+++ b/app/views/scripts/partials/database/numismatics/jettonData.phtml
@@ -39,19 +39,19 @@ echo $this->jettonEditDeleteLink()
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseDescription)): ?>
-        Obverse description: <?php echo ucfirst($this->escape($this->obverseDescription)); ?><br/>
+        Obverse description: <?php echo $this->escape($this->escape($this->obverseDescription)); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseInscription)): ?>
-        Obverse inscription: <?php echo ucfirst($this->obverseInscription); ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseDescription)): ?>
-        Reverse description: <?php echo ucfirst($this->reverseDescription); ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseInscription)): ?>
-        Reverse inscription: <?php echo ucfirst($this->reverseInscription); ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
 
 

--- a/app/views/scripts/partials/database/numismatics/jettonData.phtml
+++ b/app/views/scripts/partials/database/numismatics/jettonData.phtml
@@ -1,4 +1,4 @@
-<h4 class="lead">Jetton/ token data</h4>
+<h4 class="lead">Jetton / token data</h4>
 <?php
 echo $this->jettonEditDeleteLink()
     ->setFindID($this->id)

--- a/app/views/scripts/partials/database/numismatics/medievalData.phtml
+++ b/app/views/scripts/partials/database/numismatics/medievalData.phtml
@@ -90,19 +90,19 @@
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseDescription)): ?>
-        Obverse description: <?php echo ucfirst($this->obverseDescription); ?><br/>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseInscription)): ?>
-        Obverse inscription: <?php echo ucfirst($this->obverseInscription); ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseDescription)): ?>
-        Reverse description: <?php echo ucfirst($this->reverseDescription); ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseInscription)): ?>
-        Reverse inscription: <?php echo ucfirst($this->reverseInscription); ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseMintmark)) : ?>

--- a/app/views/scripts/partials/database/numismatics/modernData.phtml
+++ b/app/views/scripts/partials/database/numismatics/modernData.phtml
@@ -33,16 +33,16 @@
                 title="view all records assigned to <?php echo $this->mintName; ?>"><i class="icon-info-sign"></i></a><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseDescription)): ?>
-        Obverse description: <?php echo ucfirst($this->obverseDescription); ?><br/>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseInscription)): ?>
-        Obverse inscription: <?php echo $this->obverseInscription; ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseDescription)): ?>
-        Reverse description: <?php echo ucfirst($this->reverseDescription); ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseInscription)): ?>
-        Reverse inscription: <?php echo $this->reverseInscription; ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->dieAxisName)): ?>
         Die axis measurement: <?php echo $this->escape($this->dieAxisName); ?><br/>

--- a/app/views/scripts/partials/database/numismatics/postmedievalData.phtml
+++ b/app/views/scripts/partials/database/numismatics/postmedievalData.phtml
@@ -94,19 +94,19 @@
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseDescription)) : ?>
-        Obverse description: <?php echo $this->obverseDescription; ?><br/>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->obverseInscription)) : ?>
-        Obverse inscription: <?php echo $this->obverseInscription; ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseDescription)) : ?>
-        Reverse description: <?php echo $this->reverseDescription; ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseInscription)) : ?>
-        Reverse inscription: <?php echo $this->reverseInscription; ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
 
     <?php if (!is_null($this->reverseMintmark)) : ?>

--- a/app/views/scripts/partials/database/numismatics/romanData.phtml
+++ b/app/views/scripts/partials/database/numismatics/romanData.phtml
@@ -69,23 +69,23 @@
         <span rel="obverse">
         <?php if (!is_null($this->obverseDescription)) : ?>
             <br/>
-            Obverse description: <span property="description"><?php echo $this->obverseDescription; ?></span>
+            Obverse description: <span property="description"><?php echo $this->escape($this->obverseDescription); ?></span>
         <?php endif; ?>
 
             <?php if (!is_null($this->obverseInscription)) : ?>
                 <br/>
-            Obverse inscription: <span property="legend"><?php echo $this->obverseInscription; ?></span>
+            Obverse inscription: <span property="legend"><?php echo $this->escape($this->obverseInscription); ?></span>
             <?php endif; ?>
     </span>
 
     <span rel="reverse">
         <?php if (!is_null($this->reverseDescription)) : ?>
             <br/>
-            Reverse description: <span property="description"><?php echo $this->reverseDescription; ?></span>
+            Reverse description: <span property="description"><?php echo $this->escape($this->reverseDescription); ?></span>
         <?php endif; ?>
         <?php if (!is_null($this->reverseInscription)) : ?>
             <br/>
-            Reverse inscription: <span property="legend"><?php echo $this->reverseInscription; ?></span>
+            Reverse inscription: <span property="legend"><?php echo $this->escape($this->reverseInscription); ?></span>
         <?php endif; ?>
     </span>
 

--- a/app/views/scripts/partials/database/numismatics/unknownData.phtml
+++ b/app/views/scripts/partials/database/numismatics/unknownData.phtml
@@ -33,16 +33,16 @@
                 title="view all records assigned to <?php echo $this->mintName; ?>"><i class="icon-search"></i></a><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseDescription)): ?>
-        Obverse description: <?php echo ucfirst($this->obverseDescription); ?><br/>
+        Obverse description: <?php echo $this->escape($this->obverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->obverseInscription)): ?>
-        Obverse inscription: <?php echo $this->obverseInscription; ?><br/>
+        Obverse inscription: <?php echo $this->escape($this->obverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseDescription)): ?>
-        Reverse description: <?php echo ucfirst($this->reverseDescription); ?><br/>
+        Reverse description: <?php echo $this->escape($this->reverseDescription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->reverseInscription)): ?>
-        Reverse inscription: <?php echo $this->reverseInscription; ?><br/>
+        Reverse inscription: <?php echo $this->escape($this->reverseInscription); ?><br/>
     <?php endif; ?>
     <?php if (!is_null($this->dieAxisName)): ?>
         Die axis measurement: <?php echo $this->escape($this->dieAxisName); ?><br/>


### PR DESCRIPTION
Numismatic inscriptions/descriptions of coins on PAS are currently displayed with the first letter uppercased. 

This is an issue for numismatic data, as in many cases, the case of the text is essential information. For example, the inscription hEN/RIO/… is shown as HEN/RIO, currently. 

To resolve this, descriptions and inscriptions for numismatic data will be shown exactly as entered.