### PR TITLE
fix: permissions issue with 404 not found when editing

### DIFF
--- a/app/modules/database/controllers/ArtefactsController.php
+++ b/app/modules/database/controllers/ArtefactsController.php
@@ -465,6 +465,7 @@ class Database_ArtefactsController extends Pas_Controller_Action_Admin
             }
 
             $currentFindDetails = $this->getFinds()->fetchRow('id = ' . $id);
+            $this->view->find = $currentFindDetails;
             if ($this->getRequest()->isPost()) {
                 if ($form->isValid($this->_request->getPost())) {
                     $updatedFindDetails = $form->getValues();


### PR DESCRIPTION
When editing a record as a FLO (flos role), the function EditCheck will authenticate the edit when the institution matches the FLOs.

However, when a POST request is sent the institution found in the view is not set, and as such the check fails.

To fix this, we set the $this->find->view var before checking if it is a post request.