### PR TITLE
fix: allow upper case .jpg extensions

### DIFF
--- a/app/modules/database/controllers/AjaxController.php
+++ b/app/modules/database/controllers/AjaxController.php
@@ -976,7 +976,7 @@ class Database_AjaxController extends Pas_Controller_Action_Ajax
                 $reNamer = new Pas_Image_Rename();
                 // Clean the filename
                 $params = $this->getAllParams();
-                $cleaned = $reNamer->strip(uniqid($params['findID'] . '_', false), $filename['extension']);
+                $cleaned = $reNamer->strip(uniqid($params['findID'] . '_', false), strtolower($filename['extension']));
                 // Rename the file
                 $adapter->addFilter('rename', $cleaned);
                 // receive the files into the user directory


### PR DESCRIPTION
Images with an upper case .JPG would not work, due to the database saving the image name as lowercase .jpg.

As such, all extensions are lowercased.