### PR TITLE
refactor: move map perms to UserPermissions class

### DIFF
--- a/app/models/UserPermissions.php
+++ b/app/models/UserPermissions.php
@@ -12,6 +12,7 @@ class UserPermissions
     public const VIEW_RECORD_IDENTIFIERS = 'ViewRecordIdentifiers';
     public const VIEW_RECORD_FINDERS = 'ViewRecordFinders';
     public const VIEW_RECORD_RECORDERS = 'ViewRecordRecorders';
+    public const VIEW_FULL_MAP_DETAIL = 'ViewFullMapDetail';
     protected string $userRole;
 
     protected array $permissions = array(
@@ -20,56 +21,64 @@ class UserPermissions
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => true,
             'ViewRecordFinders' => true,
-            'ViewRecordRecorders' => true
+            'ViewRecordRecorders' => true,
+            'ViewFullMapDetail' => true
         ),
         'hoard' => array(
             'ViewKnownAsGeoData' => true,
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => true,
             'ViewRecordFinders' => false,
-            'ViewRecordRecorders' => true
+            'ViewRecordRecorders' => true,
+            'ViewFullMapDetail' => true
         ),
         'fa' => array(
             'ViewKnownAsGeoData' => true,
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => true,
             'ViewRecordFinders' => true,
-            'ViewRecordRecorders' => true
+            'ViewRecordRecorders' => true,
+            'ViewFullMapDetail' => true
         ),
         'treasure' => array(
             'ViewKnownAsGeoData' => true,
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => true,
             'ViewRecordFinders' => true,
-            'ViewRecordRecorders' => true
+            'ViewRecordRecorders' => true,
+            'ViewFullMapDetail' => true
         ),
         'flos' => array(
             'ViewKnownAsGeoData' => true,
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => true,
             'ViewRecordFinders' => true,
-            'ViewRecordRecorders' => true
+            'ViewRecordRecorders' => true,
+            'ViewFullMapDetail' => true
         ),
         'hero' => array(
             'ViewKnownAsGeoData' => true,
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => true,
             'ViewRecordFinders' => false,
-            'ViewRecordRecorders' => true
+            'ViewRecordRecorders' => true,
+            'ViewFullMapDetail' => true
         ),
         'research' => array(
             'ViewKnownAsGeoData' => true,
             'ViewGeoData' => true,
             'ViewRecordIdentifiers' => false,
             'ViewRecordFinders' => false,
-            'ViewRecordRecorders' => false
+            'ViewRecordRecorders' => false,
+            'ViewFullMapDetail' => true
         ),
         'member' => array(
             'ViewKnownAsGeoData' => false,
             'ViewGeoData' => false,
             'ViewRecordIdentifiers' => false,
             'ViewRecordFinders' => false,
-            'ViewRecordRecorders' => false
+            'ViewRecordRecorders' => false,
+            'ViewFullMapDetail' => false
         ),
     );
 

--- a/app/modules/database/views/scripts/search/map.phtml
+++ b/app/modules/database/views/scripts/search/map.phtml
@@ -40,15 +40,8 @@ echo $this->googleDynamicMap(true);
     $(document).ready(function() {
 
 <?php
-$user = new Pas_User_Details();
-$person = $user->getPerson();
-if ($person) {
-    $role = $person->role;
-} else {
-    $role = NULL;
-}
-$allowed = array('admin', 'fa', 'flos', 'research', 'treasure', 'hoard');
-if (in_array($role, $allowed)) {
+$userPermissions = new UserPermissions();
+if ($userPermissions->canRole(UserPermissions::VIEW_FULL_MAP_DETAIL)) {
     $maxzoom = 18;
     $minzoom = 1;
 } else {

--- a/app/views/scripts/partials/database/geodata/findSpot.phtml
+++ b/app/views/scripts/partials/database/geodata/findSpot.phtml
@@ -54,19 +54,8 @@ echo $this->findSpotEditDeleteLink()->setController($controller)
     <?php $this->inlineScript()->captureStart(); ?>
     $(document).ready(function() {
     <?php
-    $user = new Pas_User_Details();
-    $person = $user->getPerson();
-    if ($person) {
-        $role = $person->role;
-    } else {
-        $role = NULL;
-    }
-    $allowed = array(
-        'admin', 'fa', 'flos',
-        'research', 'treasure', 'hero',
-        'hoard'
-    );
-    if (in_array($role, $allowed)) {
+    $userPermissions = new UserPermissions();
+    if ($userPermissions->canRole(UserPermissions::VIEW_FULL_MAP_DETAIL)) {
         $maxzoom = 18;
         $minzoom = 1;
     } else {

--- a/app/views/scripts/partials/database/geodata/unAuthorisedFindSpot.phtml
+++ b/app/views/scripts/partials/database/geodata/unAuthorisedFindSpot.phtml
@@ -5,21 +5,8 @@
     <?php $this->inlineScript()->captureStart(); ?>
     $(document).ready(function() {
     <?php
-    $user = new Pas_User_Details();
-    $person = $user->getPerson();
-    if ($person) {
-        $role = $person->role;
-    } else {
-        $role = NULL;
-    }
-    $allowed = array('admin', 'fa', 'flos', 'research', 'treasure', 'hoard');
-    if (in_array($role, $allowed)) {
-        $maxzoom = 18;
-        $minzoom = 1;
-    } else {
-        $maxzoom = 11;
-        $minzoom = 1;
-    }
+    $maxzoom = 11;
+    $minzoom = 1;
     ?>
 
     var max = <?php echo $maxzoom; ?>;


### PR DESCRIPTION
The current map zoom permissions are hardcoded in the file. For consistency, and to reduce complexity of changes, this change moves the permission to the UsersPermissions class as ViewFullMapDetail.

For the unAuthorisedFindSpot file, force all users to not be able to zoom in. This is as this version of the map is only shown when users should not see any detail, and as such we can remove this permissions check all together.