### PR TITLE
103338 – Contact us message to PAS mailbox 

### DIFF
--- a/app/config/emails.ini
+++ b/app/config/emails.ini
@@ -43,3 +43,6 @@ admin.projectName = The Portable Antiquities Scheme
 
 transaction.email = info@finds.org.uk
 transaction.name = PAS Head Office
+
+pasmailbox.email = past@britishmuseum.org
+pasmailbox.name = PAS Head Office

--- a/app/modules/about/controllers/ContactusController.php
+++ b/app/modules/about/controllers/ContactusController.php
@@ -16,6 +16,8 @@
  */
 class About_ContactUsController extends Pas_Controller_Action_Admin
 {
+    protected $pasMailboxEmail;
+    protected $pasMailboxEmailName;
 
     /** Initialize the acl helper and messenger
      * @access public
@@ -23,6 +25,8 @@ class About_ContactUsController extends Pas_Controller_Action_Admin
     public function init()
     {
         $this->_helper->acl->allow('public', null);
+        $this->pasMailboxEmail = Zend_Registry::get('config')->pasmailbox->email;
+        $this->pasMailboxEmailName = Zend_Registry::get('config')->pasmailbox->name;
     }
 
     /** The action that allows people to send in requests via the contact us
@@ -44,12 +48,22 @@ class About_ContactUsController extends Pas_Controller_Action_Admin
 
                 $messages = new Messages();
                 $messages->addComplaint($form->getValues());
+
+                //Use a different to address than default, which is the sender email. However, if not set, fall back
+                //to sender address by not setting this array.
+                $to = null;
+                if($this->pasMailboxEmail && $this->pasMailboxEmailName) {
+                    $to[] = array(
+                        'email' => $this->pasMailboxEmail,
+                        'name' => $this->pasMailboxEmailName
+                    );
+                }
                 $cc = array();
                 $cc[] = array(
                     'email' => $form->getvalue('comment_author_email'),
                     'name' => $form->getValue('comment_author')
                 );
-                $this->_helper->mailer($form->getValues(), 'contactUs', null, $cc);
+                $this->_helper->mailer($form->getValues(), 'contactUs', $to, $cc);
                 $this->getFlash()->addMessage('Your enquiry has been submitted to the Scheme');
                 $this->redirect('about/contactus/');
             } else {


### PR DESCRIPTION
When users contact us using the form on the website, and email should be sent to them as a receipt, and the PAS mailbox. 