### PR TITLE
103718 – Error Report email 

### DIFF
--- a/app/modules/database/controllers/ArtefactsController.php
+++ b/app/modules/database/controllers/ArtefactsController.php
@@ -737,19 +737,17 @@ class Database_ArtefactsController extends Pas_Controller_Action_Admin
         }
         $cc = $this->_getAdviser($objecttype, $broadperiod);
         if ($this->_user) {
-            $from = array(
+            $from =
                 array(
                     'email' => $this->_user->email,
                     'name' => $this->_user->fullname
-                )
-            );
+                );
         } else {
-            $from = array(
+            $from =
                 array(
                     'email' => $data['comment_author_email'],
                     'name' => $data['comment_author']
-                )
-            );
+                );
         }
         $assignData = array_merge($to['0'], $data);
         $cc[] = $from;

--- a/app/modules/database/controllers/ArtefactsController.php
+++ b/app/modules/database/controllers/ArtefactsController.php
@@ -749,7 +749,7 @@ class Database_ArtefactsController extends Pas_Controller_Action_Admin
                     'name' => $data['comment_author']
                 );
         }
-        $assignData = array_merge($to['0'], $data);
+        $assignData = array_merge((array)$to['0'], $data);
         $cc[] = $from;
         $this->_helper->mailer($assignData, 'errorSubmission', $to, $cc);
     }

--- a/app/views/scripts/email/errorSubmission.phtml
+++ b/app/views/scripts/email/errorSubmission.phtml
@@ -22,6 +22,7 @@
     <li>Find number: <?php echo $this->old_findID; ?></li>
     <li>Originally created by: <?php echo $this->name; ?></li>
     <li>Date created: <?php echo $this->timeAgoInWords($this->created); ?></li>
+    <li>Submitter email address: <?= htmlspecialchars($this->comment_author_email); ?></li>
 </ul>
 <p>Thank you for taking the time to submit an error to us.<br/>
     We appreciate that you have taken the time to improve our database.

--- a/app/views/scripts/email/errorSubmission.phtml
+++ b/app/views/scripts/email/errorSubmission.phtml
@@ -1,5 +1,5 @@
 <?php $this->mail->setSubject('An error report has been entered for ' . $this->old_findID); ?>
-<p>Dear <?php echo $this->escape($this->splitName()->setName($this->name)); ?>,</p>
+<p>Dear <?php echo $this->escape($this->splitName()->setName($this->name ?? 'User')); ?>,</p>
 
 <?php if ($this->institution === 'PUBLIC'): ?>
     <p>As the creator of the record, an error report has been submitted by <?php echo


### PR DESCRIPTION
The error reporting function, which allows users to report issues with records on the website, no longer included the reporter in the recipient list. This has led to an issue wherein the FLO does not know who to respond to regarding the error.  

Not only has this bug been fixed, but the email of the reporter is now included in the email to ensure that staff are aware who sent the email.  
