### PR TITLE
104988 - Cookiebot placeholder 

### DIFF
--- a/app/modules/database/views/scripts/search/map.phtml
+++ b/app/modules/database/views/scripts/search/map.phtml
@@ -25,6 +25,16 @@ $this->metaBase()->setDescription($this->title())
         <div class="span9">
             <div id="map" style="min-height:1000px;">
                 <div id="loading"></div>
+                <!-- If stats cookies are not accepted -->
+                <div class="embed-container" style="--aspect-ratio:4/3">
+                    <div class="cookieconsent-optout-preferences cookie-placeholder dark ">
+                        <div style="color:white; font-family: Arial, sans-serif;">
+                            Please <a href="javascript:Cookiebot.renew()"
+                                      style="color:white !important; text-decoration:underline;">accept
+                                preferences-cookies</a> to see this map
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="span3">

--- a/app/views/scripts/partials/database/geodata/findSpot.phtml
+++ b/app/views/scripts/partials/database/geodata/findSpot.phtml
@@ -19,6 +19,17 @@ echo $this->findSpotEditDeleteLink()->setController($controller)
 	<?php echo $this->lon; ?>&zoom=14&size=640x300&maptype=terrain&markers=color:green|label:G|
 	<?php echo $this->lat; ?>,<?php echo $this->lon; ?>"/>
         </noscript>
+
+        <!-- If stats cookies are not accepted -->
+        <div class="embed-container" style="--aspect-ratio:21/9">
+            <div class="cookieconsent-optout-preferences cookie-placeholder dark ">
+                <div style="color:white; font-family: Arial, sans-serif;">
+                    Please <a href="javascript:Cookiebot.renew()"
+                              style="color:white !important; text-decoration:underline;">accept
+                        preferences-cookies</a> to see this map
+                </div>
+            </div>
+        </div>
     </div>
     <?php
     $allowed = array(

--- a/app/views/scripts/partials/database/geodata/unAuthorisedFindSpot.phtml
+++ b/app/views/scripts/partials/database/geodata/unAuthorisedFindSpot.phtml
@@ -139,6 +139,17 @@
                 alt="Findspot map generated via google static maps"/>
         </noscript>
         <!-- render static map finish -->
+
+        <!-- If stats cookies are not accepted -->
+        <div class="embed-container" style="--aspect-ratio:21/9">
+            <div class="cookieconsent-optout-preferences cookie-placeholder dark ">
+                <div style="color:white; font-family: Arial, sans-serif;">
+                    Please <a href="javascript:Cookiebot.renew()"
+                              style="color:white !important; text-decoration:underline;">accept
+                        preferences-cookies</a> to see this map
+                </div>
+            </div>
+        </div>
     </div>
     <!-- End of map container -->
 <?php endif; ?>

--- a/public_html/css/custom.css
+++ b/public_html/css/custom.css
@@ -85,8 +85,11 @@
     -webkit-transform: translate(-50%, -50%);
     -ms-transform: translate(-50%, -50%);
     width: 100%;
-    height: 100%;
     text-align: center;
+}
+
+.embed-container [class*="cookieconsent-"] > div[class*="twitter"] {
+    height:100%;
 }
 
 .cookie-placeholder--reload {
@@ -123,7 +126,7 @@
     }
 }
 
-/* END COOKIEBOT 
+/* END COOKIEBOT
 -------------------------------------------------- */
 
 @media screen and (max-width: 576px) {

--- a/public_html/css/custom.css
+++ b/public_html/css/custom.css
@@ -53,10 +53,10 @@
 .cookie-show {
     visibility: visible !important;
     opacity:0;
-    animation: fadeIn 2s forwards;
-    -webkit-animation: fadeIn 2s forwards;
-    animation-delay: 5s;
-    -webkit-animation-delay: 5s;
+    animation: fadeIn 1s forwards;
+    -webkit-animation: fadeIn 1s forwards;
+    animation-delay: 2s;
+    -webkit-animation-delay: 2s;
 }
 
 .embed-container {


### PR DESCRIPTION
Adds a Cookiebot placeholder to the Google Map embeds if the user does not accept preferences cookies. Currently, the user will see an empty space with no way of accepting the cookie. 