### PR TITLE
105764 - Treasure Minutes Page Text 

### DIFF
--- a/app/modules/treasure/views/scripts/minutes/index.phtml
+++ b/app/modules/treasure/views/scripts/minutes/index.phtml
@@ -11,10 +11,12 @@ $this->metaBase()
 </h2>
 
 <p>
-    The minutes of the meetings of the Treasure Valuation Committee are made public at regular intervals, 
-    once valuations have been determined for all of the cases discussed therein. Personal information and 
-    other sensitive information is appropriately redacted. Dates of past meetings with available minutes are 
-    listed below. Minutes of meetings prior to 2007 are not available in electronic form. 
+    The minutes of the meetings of the Treasure Valuation Committee are made public once the Secretary of State has 
+    made a decision on the recommendation for the cases discussed therein. To allow for this, the minutes are normally 
+    published once a year, in December of the following year. For examples, the minutes of meetings from 2021 were 
+    published in December 2022. Personal information and other sensitive information are appropriately redacted. 
+    Click on any of the dates below to view the minutes for that meeting. Minutes of meetings prior to 2007 are not 
+    available in electronic form.
 </p>
 
 <ul>


### PR DESCRIPTION
Treasure minutes page has had the text altered to explain why it can take till the following December for the minutes to be published. 