### PR TITLE
106030 - Image Name 

### DIFF
--- a/app/modules/database/controllers/AjaxController.php
+++ b/app/modules/database/controllers/AjaxController.php
@@ -922,6 +922,7 @@ class Database_AjaxController extends Pas_Controller_Action_Ajax
      *
      * @access public
      * @throws \Pas_Exception_NotAuthorised
+     * @throws Pas_Exception
      */
     public function upload()
     {
@@ -970,13 +971,16 @@ class Database_AjaxController extends Pas_Controller_Action_Ajax
 
             // Loop through the submitted files
             foreach ($files as $file => $info) {
-                // Clean up the image name for crappy characters
+                // Clean up the image name
                 $filename = pathinfo($adapter->getFileName($file));
-                // Instantiate the re-namer
-                $reNamer = new Pas_Image_Rename();
-                // Clean the filename
                 $params = $this->getAllParams();
-                $cleaned = $reNamer->strip(uniqid($params['findID'] . '_', false), strtolower($filename['extension']));
+
+                $oldFindID = (new Finds())->getFindNumbersEtc($params['findID'])[0]['old_findID'];
+                if (empty($oldFindID)) {
+                    throw new Pas_Exception('Cannot find old Find ID', 500);
+                }
+
+                $cleaned = uniqid($oldFindID . '_', false) . '.' . strtolower($filename['extension']);
                 // Rename the file
                 $adapter->addFilter('rename', $cleaned);
                 // receive the files into the user directory


### PR DESCRIPTION
The current method of renaming images uses the numeric ID of the record as the prefix of the name. However, this has resulted in file names that have little meaning for the end user.

The old ID, which is what is seen on the UI and what users are most familiar with, includes an ID and a prefix for the institution they are part of. By using the old ID as part of the naming scheme, we create more usable names that are more understandable for users.