### PR TITLE
106093 - User image directory

### DIFF
--- a/app/modules/admin/controllers/UsersController.php
+++ b/app/modules/admin/controllers/UsersController.php
@@ -228,12 +228,14 @@ class Admin_UsersController extends Pas_Controller_Action_Admin
                 );
                 $username = $form->getValue('username');
                 $this->getUsers()->add($insertData);
+                $imagePath = rtrim(IMAGE_PATH,'/') . '/';
+
                 $directories = array(
-                    IMAGE_PATH . $username,
-                    IMAGE_PATH . $username . '/small/',
-                    IMAGE_PATH . $username . '/medium/',
-                    IMAGE_PATH . $username . '/display/',
-                    IMAGE_PATH . $username . '/zoom/'
+                    $imagePath . $username,
+                    $imagePath . $username . '/small/',
+                    $imagePath . $username . '/medium/',
+                    $imagePath . $username . '/display/',
+                    $imagePath . $username . '/zoom/'
                 );
 
                 foreach ($directories as $dir) {


### PR DESCRIPTION
When adding a user via the admin section, the users image directory is missing a slash in between the username and the image folder. This will cause manually created users to have image directories in the root public_html folder.