### PR TITLE
Disable URL passthrough

### DIFF
--- a/public_html/js/cookiebot-google-consent-mode.js
+++ b/public_html/js/cookiebot-google-consent-mode.js
@@ -15,4 +15,4 @@ gtag("consent", "default", {
     wait_for_update: 2000,
 });
 gtag("set", "ads_data_redaction", true);
-gtag("set", "url_passthrough", true);
+gtag("set", "url_passthrough", false);


### PR DESCRIPTION
Set the Google Consent Mode `url_passthrough` setting to **false** to stop _ga and _gl parameters appearing in the URL.